### PR TITLE
Add API to query default options from parallel

### DIFF
--- a/conf/webpack.dev.config.js
+++ b/conf/webpack.dev.config.js
@@ -11,7 +11,7 @@ module.exports = new Config().extend({
     }
 }).merge({
     entry: {
-        example: "./example/browser-example.js"
+        example: "./example/browser-example.ts"
     },
     debug: true,
     devtool: "#inline-source-map",

--- a/example/browser-example.ts
+++ b/example/browser-example.ts
@@ -1,6 +1,6 @@
-const Parallel = require("../src/browser/index-commonjs");
+import parallel from "../src/browser/index";
 
-function fibonacci(x) {
+/*function fibonacci(x: number): number {
     this.info = x;
     if (x < 0) {
         return NaN;
@@ -14,7 +14,7 @@ function fibonacci(x) {
     }
 
     return recFib(x);
-}
+} */
 
 /*const data: number[] = [];
  for (let i = 0; i < 40; ++i) {
@@ -23,7 +23,7 @@ function fibonacci(x) {
 
  Parallel.collection(data).map(fibonacci).value().then(result => console.log("Result", result)); */
 
-function busyWait(x) {
+function busyWait<T>(x: T): T {
     let i = 0;
     for (; i < Math.pow(10,  8); ++i) {
         // nothing
@@ -31,13 +31,13 @@ function busyWait(x) {
     return x;
 }
 
-Parallel
+parallel
     .range(0, 99, 2)
     .map(busyWait)
     .reduce(0, (memo, value) => memo + value)
     .then(result => console.log("Using range: ", result));
 
-Parallel.times(100, busyWait).value().then(result => console.log("Using times", result));
+parallel.times(100, busyWait).value().then(result => console.log("Using times", result));
 
 /*console.profile("Sync");
  const results: number[] = [];

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,8 +15,7 @@ module.exports = function (config) {
 
         // list of files / patterns to load in the browser
         files: [
-            './test/tests.js',
-            'test/integration-tests.js'
+            './test/tests.js'
         ],
 
         // list of files to exclude
@@ -29,6 +28,11 @@ module.exports = function (config) {
         },
 
         webpack: require("./webpack.config.js"),
+        webpackMiddleware: {
+            stats: {
+                chunks: false
+            }
+        },
 
         // test results reporter to use
         // possible values: 'dots', 'progress'

--- a/src/common/parallel/parallel-chain.ts
+++ b/src/common/parallel/parallel-chain.ts
@@ -10,12 +10,12 @@ export interface ParallelTaskScheduling {
 }
 
 export interface ParallelChain<TIn, TOut> {
-    map<TResult>(mapper: (element: TOut, index: number) => TResult): ParallelChain<TIn, TResult>;
+    map<TResult>(mapper: (this: void, element: TOut, index: number) => TResult): ParallelChain<TIn, TResult>;
 
-    reduce(defaultValue: TOut, accumulator: (memo: TOut, value: TOut, index: number) => TOut): Promise<TOut>;
-    reduce<TResult>(defaultValue: TResult, accumulator: (memo: TResult, value: TOut, index: number) => TResult, combiner: (subResult1: TResult, subResult2: TResult) => TResult): Promise<TResult>;
+    reduce(defaultValue: TOut, accumulator: (this: void, memo: TOut, value: TOut, index: number) => TOut): Promise<TOut>;
+    reduce<TResult>(defaultValue: TResult, accumulator: (this: void, memo: TResult, value: TOut, index: number) => TResult, combiner: (this: void, subResult1: TResult, subResult2: TResult) => TResult): Promise<TResult>;
 
-    filter(predicate: (value: TOut, index: number) => boolean): ParallelChain<TIn, TOut>;
+    filter(predicate: (this: void, value: TOut, index: number) => boolean): ParallelChain<TIn, TOut>;
 
     // sortBy?
 
@@ -31,11 +31,11 @@ export class ParallelChainImpl<TIn, TOut> implements ParallelChain<TIn, TOut> {
     constructor(public generator: ParallelGenerator, private __actions: ParallelAction[] = [], private options: DefaultInitializedParallelOptions) {
     }
 
-    map<TResult>(mapper: (element: TOut) => TResult): ParallelChain<TIn, TResult> {
+    map<TResult>(mapper: (this: void, element: TOut) => TResult): ParallelChain<TIn, TResult> {
         return this._chain<TResult>(ParallelWorkerFunctions.map, mapper);
     }
 
-    reduce<TResult>(defaultValue: TResult, accumulator: (memo: TResult, value: TOut) => TResult, combiner?: (sub1: TResult, sub2: TResult) => TResult): Promise<TResult> {
+    reduce<TResult>(defaultValue: TResult, accumulator: (this: void, memo: TResult, value: TOut) => TResult, combiner?: (this: void, sub1: TResult, sub2: TResult) => TResult): Promise<TResult> {
         return this._chain(ParallelWorkerFunctions.reduce, accumulator, defaultValue)._schedule((intermediateResults: TResult[][]) => {
             let sum = defaultValue;
             let combineOperation: (accumulatedValue: TResult, value: TResult) => TResult = combiner || accumulator as any;
@@ -48,7 +48,7 @@ export class ParallelChainImpl<TIn, TOut> implements ParallelChain<TIn, TOut> {
         });
     }
 
-    filter(predicate: (value: TOut) => boolean): ParallelChain<TIn, TOut> {
+    filter(predicate: (this: void, value: TOut) => boolean): ParallelChain<TIn, TOut> {
         return this._chain<TOut>(ParallelWorkerFunctions.filter, predicate);
     }
 

--- a/src/common/parallel/parallel-generator.ts
+++ b/src/common/parallel/parallel-generator.ts
@@ -25,17 +25,17 @@ export interface ParallelGenerator {
  * Generator for arrays
  */
 export class ConstCollectionGenerator<T> implements ParallelGenerator {
-    constructor(private __value: T[]) {}
+    constructor(private __collection: T[]) {}
 
     get length(): number {
-        return this.__value.length;
+        return this.__collection.length;
     }
 
     serializeSlice(index: number, numberOfItems: number, functionCallSerializer: FunctionCallSerializer): SerializedFunctionCall {
         const start = numberOfItems * index;
         const end = start + numberOfItems;
 
-        return functionCallSerializer.serializeFunctionCall(ParallelWorkerFunctions.toIterator, this.__value.slice(start, end));
+        return functionCallSerializer.serializeFunctionCall(ParallelWorkerFunctions.toIterator, this.__collection.slice(start, end));
     }
 }
 
@@ -71,9 +71,9 @@ export class RangeGenerator implements ParallelGenerator {
  */
 export class TimesGenerator<T> implements ParallelGenerator {
     readonly times: number;
-    readonly iteratee: (time: number) => T;
+    readonly iteratee: (this: void, time: number) => T;
 
-    constructor(times: number, iteratee: (time: number) => T) {
+    constructor(times: number, iteratee: (this: void, time: number) => T) {
         this.times = times;
         this.iteratee = iteratee;
     }

--- a/src/common/parallel/parallel-worker-functions.ts
+++ b/src/common/parallel/parallel-worker-functions.ts
@@ -18,7 +18,7 @@ export const ParallelWorkerFunctions = {
         return toArray<TResult>(iterator as any);
     },
 
-    map<T, TResult>(iterator: Iterator<T>, iteratee: (value: T) => TResult): Iterator<TResult> {
+    map<T, TResult>(iterator: Iterator<T>, iteratee: (this: void, value: T) => TResult): Iterator<TResult> {
         return {
             next(): IteratorResult<TResult> {
                 const result = iterator.next();
@@ -33,7 +33,7 @@ export const ParallelWorkerFunctions = {
         };
     },
 
-    filter<T>(iterator: Iterator<T>, predicate: (value: T) => boolean): Iterator<T> {
+    filter<T>(iterator: Iterator<T>, predicate: (this: void, value: T) => boolean): Iterator<T> {
         return {
             next() {
                 let current: IteratorResult<T>;
@@ -48,7 +48,7 @@ export const ParallelWorkerFunctions = {
         };
     },
 
-    reduce<T, TResult>(defaultValue: TResult, iterator: Iterator<T>, iteratee: (accumulatedValue: TResult, value: T | undefined) => TResult): Iterator<TResult> {
+    reduce<T, TResult>(defaultValue: TResult, iterator: Iterator<T>, iteratee: (this: void, accumulatedValue: TResult, value: T | undefined) => TResult): Iterator<TResult> {
         let accumulatedValue = defaultValue;
         let current: IteratorResult<T>;
 
@@ -73,7 +73,7 @@ export const ParallelWorkerFunctions = {
         };
     },
 
-    times<TResult>(start: number, end: number, iteratee: (i: number) => TResult): Iterator<TResult> {
+    times<TResult>(start: number, end: number, iteratee: (this: void, i: number) => TResult): Iterator<TResult> {
         let next = start;
         return {
             next(): IteratorResult<TResult> {

--- a/src/common/parallel/parallel.ts
+++ b/src/common/parallel/parallel.ts
@@ -28,7 +28,7 @@ export interface Parallel {
      * @param generator the generator used to create the array elements
      * @param options options configuring the computation behaviou
      */
-    times<TResult>(n: number, generator: (n: number) => TResult, options?: ParallelOptions): ParallelChain<TResult, TResult>;
+    times<TResult>(n: number, generator: (this: void, n: number) => TResult, options?: ParallelOptions): ParallelChain<TResult, TResult>;
 }
 
 export function parallelFactory(configuration: Configuration): Parallel {
@@ -42,8 +42,8 @@ export function parallelFactory(configuration: Configuration): Parallel {
     }
 
     return {
-        collection<T>(data: T[], options?: ParallelOptions): ParallelChain<T, T> {
-            return toParallelChain(new ConstCollectionGenerator<T>(data), initOptions(options));
+        collection<T>(collection: T[], options?: ParallelOptions): ParallelChain<T, T> {
+            return toParallelChain(new ConstCollectionGenerator<T>(collection), initOptions(options));
         },
 
         range(start: number, end?: number, step?: number, options?: ParallelOptions) {
@@ -59,7 +59,7 @@ export function parallelFactory(configuration: Configuration): Parallel {
             return toParallelChain(new RangeGenerator(start, end, step), initOptions(options));
         },
 
-        times<TResult>(n: number, generator: (n: number) => TResult = ParallelWorkerFunctions.identity, options?: ParallelOptions) {
+        times<TResult>(n: number, generator: (this: void, n: number) => TResult = ParallelWorkerFunctions.identity, options?: ParallelOptions) {
             return toParallelChain(new TimesGenerator<TResult>(n, generator), initOptions(options));
         }
     };

--- a/src/common/serialization/static-function-registry.ts
+++ b/src/common/serialization/static-function-registry.ts
@@ -1,56 +1,56 @@
 import {SimpleMap} from "../util/simple-map";
 
-export const staticFunctionRegistry = function () {
-    let lastId = 0;
-    const staticFunctions = new SimpleMap<number, StaticFunction>();
+class StaticFunctionRegistryImpl {
+    private lastId = 0;
+    private staticFunctions = new SimpleMap<number, StaticFunction>();
 
-    return {
-        registerStaticFunctions(object: Object): void {
-            Object.keys(object)
-                .map(key => (object as any)[key])
-                .filter(value => typeof value === "function")
-                .forEach(func => this.registerStaticFunction(func));
-        },
+    registerStaticFunctions(object: Object): void {
+        Object.keys(object)
+            .map(key => (object as any)[key])
+            .filter(value => typeof value === "function")
+            .forEach(func => this.registerStaticFunction(func));
+    }
 
-        registerStaticFunction(func: Function): void {
-            if (this.has(func)) {
-                return;
-            }
-
-            const staticFunc = func as StaticFunction;
-            staticFunc._____id = lastId++;
-            staticFunctions.set(staticFunc._____id, staticFunc);
-        },
-
-        getId(func: Function) {
-            if (isStaticFunction(func)) {
-                return func._____id;
-            }
-            throw new Error(`The passed in function ${func} is not a static function and therefore is not part of this registry`);
-        },
-
-        has(func: Function|number): boolean {
-            if (typeof func === "number") {
-                return staticFunctions.has(func);
-            }
-
-            return isStaticFunction(func);
-        },
-
-        getFunction(id: number): Function {
-            const func = staticFunctions.get(id);
-            if (!func) {
-                throw new Error(`the function with the id ${id} is not registered as static function`);
-            }
-            return func;
-        },
-
-        reset(): void {
-            staticFunctions.clear();
-            lastId = 0;
+    registerStaticFunction(func: Function): void {
+        if (this.has(func)) {
+            return;
         }
-    };
-}();
+
+        const staticFunc = func as StaticFunction;
+        staticFunc._____id = this.lastId++;
+        this.staticFunctions.set(staticFunc._____id, staticFunc);
+    }
+
+    getId(func: Function) {
+        if (isStaticFunction(func)) {
+            return func._____id;
+        }
+        throw new Error(`The passed in function ${func} is not a static function and therefore is not part of this registry`);
+    }
+
+    has(func: Function|number): boolean {
+        if (typeof func === "number") {
+            return this.staticFunctions.has(func);
+        }
+
+        return isStaticFunction(func);
+    }
+
+    getFunction(id: number): Function {
+        const func = this.staticFunctions.get(id);
+        if (!func) {
+            throw new Error(`the function with the id ${id} is not registered as static function`);
+        }
+        return func;
+    }
+
+    reset(): void {
+        this.staticFunctions.clear();
+        this.lastId = 0;
+    }
+}
+
+export const staticFunctionRegistry = new StaticFunctionRegistryImpl();
 
 interface StaticFunction extends Function {
     _____id: number;

--- a/test/common/parallel/parallel.specs.ts
+++ b/test/common/parallel/parallel.specs.ts
@@ -7,12 +7,93 @@ import {
 
 describe("Parallel", function () {
     let parallel: Parallel;
+    let threadPool: any = {};
+    const maxConcurrencyLevel = 2;
 
     beforeEach(function () {
         parallel = parallelFactory({
-            maxConcurrencyLevel: 2,
+            maxConcurrencyLevel: maxConcurrencyLevel,
             functionLookupTable: undefined as any,
-            threadPool: undefined as any
+            threadPool: threadPool
+        });
+    });
+
+    describe("defaultOptions", function () {
+        it("returns the default configuration", function () {
+            // act
+            const options = parallel.defaultOptions();
+
+            // assert
+            expect(options).toBeDefined();
+        });
+
+        it("initializes the maxConcurrencyLevel from the configuration by default", function () {
+            // act
+            const options = parallel.defaultOptions();
+
+            // assert
+            expect(options.maxConcurrencyLevel).toBe(maxConcurrencyLevel);
+        });
+
+        it("initializes the thread pool to the thread pool from the configuration by default", function () {
+            // act
+            const options = parallel.defaultOptions();
+
+            // assert
+            expect(options.threadPool).toBe(threadPool);
+        });
+
+        it("applies the user options as new default options", function () {
+            // act
+            const options = parallel.defaultOptions({
+                maxConcurrencyLevel: 8,
+                minValuesPerWorker: 1000
+            });
+
+            // assert
+            expect(options.maxConcurrencyLevel).toBe(8);
+            expect(options.minValuesPerWorker).toBe(1000);
+        });
+
+        it("merges the given options with the existing options", function () {
+            // act
+            const options = parallel.defaultOptions({
+                maxConcurrencyLevel: 8,
+                minValuesPerWorker: 1000
+            });
+
+            // assert
+            expect(options.threadPool).toBe(threadPool);
+        });
+
+        it("unsets values if undefined is passed as option value", function () {
+            // arrange
+            parallel.defaultOptions({
+                minValuesPerWorker: 1000
+            });
+
+            // act
+            const options = parallel.defaultOptions({
+                minValuesPerWorker: undefined
+            });
+
+            // assert
+            expect(options.minValuesPerWorker).toBeUndefined();
+        });
+
+        it("throws if maxConcurrencyLevel is not a number", function () {
+            // act, assert
+            expect(() => parallel.defaultOptions({ maxConcurrencyLevel: "test" } as any)).toThrowError("The maxConcurrencyLevel is mandatory and has to be a number");
+        });
+
+        it("throws if maxConcurrencyLevel is set to undefined", function () {
+            // act, assert
+            expect(() => parallel.defaultOptions({ maxConcurrencyLevel: undefined } as any)).toThrowError("The maxConcurrencyLevel is mandatory and has to be a number");
+        });
+
+        it("throws if the thread pool is set to undefined", function () {
+            // act, assert
+            expect(() => parallel.defaultOptions({ threadPool: undefined } as any)).toThrowError("The thread pool is mandatory and cannot be unset");
         });
     });
 

--- a/test/integration-tests.js
+++ b/test/integration-tests.js
@@ -1,2 +1,0 @@
-var testsContext = require.context(".", true, /.*\.integration-specs\.ts$/);
-testsContext.keys().forEach(testsContext);

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,4 +1,4 @@
 var browser = require("../src/browser/index");
 
-var testsContext = require.context(".", true, /.*\.specs\.ts$/);
+var testsContext = require.context(".", true, /specs\.ts$/);
 testsContext.keys().forEach(testsContext);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "noImplicitThis": true,
     "noUnusedLocals": true,
     "strictNullChecks": true,
     "pretty": true,


### PR DESCRIPTION
Add a method to parallel that allows quering and adjusting the default options used by parallel. 
