### PR TITLE
Task Cancellation Support

### DIFF
--- a/src/common/parallel/parallel-stream.ts
+++ b/src/common/parallel/parallel-stream.ts
@@ -140,6 +140,14 @@ export class ParallelStreamImpl<TSubResult, TEndResult> implements ParallelStrea
 
     private _taskFailed(reason: any): void {
         this._failed = true;
+
+        // Cancel all not yet complted tasks
+        for (let i = 0; i < this._tasks.length; ++i) {
+            if (typeof(this._subResults[i]) === "undefined") {
+                this._tasks[i].cancel();
+            }
+        }
+
         this._reject(reason);
     }
 }

--- a/src/common/task/task.ts
+++ b/src/common/task/task.ts
@@ -6,6 +6,23 @@ export interface Task<T> extends PromiseLike<T> {
 
     taskDefinition: TaskDefinition;
 
+    /**
+     * Indicator if this task has been canceled.
+     */
+    isCanceled: boolean;
+
+    /**
+     * Indicator if this task should be canceled
+     */
+    readonly isCancellationRequested: boolean;
+
     catch<TResult>(onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
     catch(onrejected?: (reason: any) => void): Promise<T>;
+
+    /**
+     * Cancels the given task.
+     * This has only an effect if the task has not yet been scheduled. Already
+     * scheduled tasks cannot be terminated.
+     */
+    cancel(): void;
 }

--- a/test/common/parallel/parallel-stream.specs.ts
+++ b/test/common/parallel/parallel-stream.specs.ts
@@ -203,6 +203,9 @@ describe("ParallelStream", function () {
     class FakeTask<T> implements Task<T> {
         taskDefinition: TaskDefinition;
         private promise: Promise<T>;
+        isCanceled = false;
+        isCancellationRequested = false;
+
         resolve: (result: T) => void;
         reject: (reason: any) => void;
 
@@ -212,6 +215,8 @@ describe("ParallelStream", function () {
                 this.reject = reject;
             });
         }
+
+        cancel() {}
 
         catch(onrejected?: any): Promise<any> {
             return this.promise.catch(onrejected);


### PR DESCRIPTION
Add Cancelation support to task and integrate it into parallel stream to avoid spending computation time on already failed parallel streams 
