### PR TITLE
Set the minValuesPerTask for the monte carlo simulation

### DIFF
--- a/example/monte-carlo.ts
+++ b/example/monte-carlo.ts
@@ -334,7 +334,7 @@ export function syncMonteCarlo(options?: IMonteCarloSimulationOptions) {
 export function parallelMonteCarlo(userOptions?: IMonteCarloSimulationOptions) {
     const options = initializeOptions(userOptions);
     return parallel
-        .from(options.projects)
+        .from(options.projects, { minValuesPerTask: 2 })
         .inEnvironment(createMonteCarloEnvironment, options)
         .map(calculateProject);
 }

--- a/src/common/parallel/scheduling/default-parallel-scheduler.ts
+++ b/src/common/parallel/scheduling/default-parallel-scheduler.ts
@@ -3,7 +3,7 @@ import {AbstractParallelScheduler, IParallelTaskScheduling} from "./abstract-par
 
 /**
  * Default implementation of a parallel scheduler.
- * By default, creates as many tasks as the hardware concurrency allows ({@link IParallelOptions.maxConcurrencyLevel}).
+ * By default, creates 4 times as many tasks as the hardware concurrency allows ({@link IParallelOptions.maxConcurrencyLevel}).
  *
  * If the options define {@link IParallelOptions.maxValuesPerTask} or {@link IParallelOptions.minValuesPerTask}, then the
  * values are adjusted accordingly.


### PR DESCRIPTION
As the montecarlo simulation needs to be recalculated for each task, the
number of projects per task should at least be 2 to have achieve any
performance improvement.
