### PR TITLE
Restore Worker when not all functions could be retrieved

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "url": "https://github.com/DatenMetzgerX/parallel.es/issues"
   },
   "homepage": "https://github.com/DatenMetzgerX/parallel.es#readme",
-  "devDependencies": {
+  "dependencies": {
     "@types/jasmine": "^2.5.35",
-    "@types/lodash": "^4.14.37",
+    "@types/lodash": "^4.14.37"
+  },
+  "devDependencies": {
     "awesome-typescript-loader": "2.2.4",
     "babel-core": "6.17.0",
     "babel-plugin-transform-runtime": "6.15.0",
@@ -45,7 +47,7 @@
     "compression-webpack-plugin": "0.3.1",
     "copyfiles": "^1.0.0",
     "coveralls": "2.11.14",
-    "cross-env": "3.1.1",
+    "cross-env": "3.1.2",
     "istanbul-instrumenter-loader": "github:datenmetzgerx/istanbul-instrumenter-loader#with-patched-lib-istanbul-instrument",
     "jasmine-core": "2.5.2",
     "json-loader": "0.5.4",

--- a/src/common/worker/worker-messages.ts
+++ b/src/common/worker/worker-messages.ts
@@ -91,6 +91,11 @@ export interface IFunctionResponse extends IWorkerMessage {
      * The definition of the requested functions
      */
     functions: IFunctionDefinition[];
+
+    /**
+     * Array containing the ids of the functions that could not be resolved
+     */
+    missingFunctions: IFunctionId[];
 }
 
 /**
@@ -147,8 +152,8 @@ export function requestFunctionMessage(functionId: IFunctionId, ...otherFunction
  * @param functions the function definitions to respond to the worker slave
  * @returns the function response message
  */
-export function functionResponseMessage(functions: IFunctionDefinition[]): IFunctionResponse {
-    return { functions, type: WorkerMessageType.FunctionResponse };
+export function functionResponseMessage(functions: IFunctionDefinition[], ...missingFunctionIds: IFunctionId[]): IFunctionResponse {
+    return { functions, missingFunctions: missingFunctionIds, type: WorkerMessageType.FunctionResponse };
 }
 
 /**

--- a/test/browser/parallel.integration.specs.ts
+++ b/test/browser/parallel.integration.specs.ts
@@ -21,4 +21,17 @@ describe("ParallelIntegration", function () {
                 done();
             });
     });
+
+    it("rejects the promise if the function id is not know", function (done) {
+        parallel.from([1, 2, 3])
+            .map({
+                _______isFunctionId: true,
+                identifier: "unknown-1"
+            })
+            .then(() => done.fail())
+            .catch((error: any) => {
+                expect(error.message).toMatch(/The function ids \[unknown-1] could not be resolved by slave \d\./);
+                done();
+            });
+    });
 });

--- a/test/browser/worker-slave/browser-worker-slave-states.specs.ts
+++ b/test/browser/worker-slave/browser-worker-slave-states.specs.ts
@@ -134,6 +134,36 @@ describe("BrowserWorkerSlaveStates", function () {
             expect(changeStateSpy).toHaveBeenCalledWith(jasmine.any(ExecuteFunctionBrowserWorkerSlaveState));
         });
 
+        it("changes to idle state if some function definitions are missing", function () {
+            // arrange
+            const changeStateSpy = spyOn(slave, "changeState");
+            spyOn(slave, "postMessage");
+
+            // act
+            state.onMessage(createMessage(functionResponseMessage([{
+                argumentNames: ["x"],
+                body: "return x;",
+                id: functionId("test", 0)
+            }], functionId("test", 0))));
+
+            // assert
+            expect(changeStateSpy).toHaveBeenCalledWith(jasmine.any(IdleBrowserWorkerSlaveState));
+        });
+
+        it("reports an error if some function definitions are missing", function () {
+            // arrange
+            const slavePostMessage = spyOn(slave, "postMessage");
+            // act
+            state.onMessage(createMessage(functionResponseMessage([{
+                argumentNames: ["x"],
+                body: "return x;",
+                id: functionId("test", 0)
+            }], functionId("missing", 1), functionId("missing", 2))));
+
+            // assert
+            expect(slavePostMessage).toHaveBeenCalledWith(jasmine.objectContaining({ error: jasmine.objectContaining({ message: `"The function ids [missing-1, missing-2] could not be resolved by slave NaN."` })}));
+        });
+
         it("registers the retrieved functions in the slave cache", function () {
             // arrange
             spyOn(slave, "changeState");


### PR DESCRIPTION
Up to now, the browser worker thread thrown an error if a function request could not be fulfilled. This causes several issues
1. The parallel promise is not rejected... instead it is never fulfilled
2. The worker thread stays in the wait for function response state forever

This change fixes the issue by always returning a function response but explicitly list the missing functions. The worker then changes back to idle state and rejects the work (what results in a rejected promise)
