### PR TITLE
Strip Thread Pool api to the absolut minimum

### DIFF
--- a/src/api/browser.ts
+++ b/src/api/browser.ts
@@ -17,10 +17,15 @@ export * from "./shared";
 const functionLookupTable = new DynamicFunctionRegistry();
 const maxConcurrencyLevel = (window.navigator as any)["hardwareConcurrency"] || 4;
 const functionCallSerializer = new FunctionCallSerializer(functionLookupTable);
-const threadPool = new DefaultThreadPool(new BrowserWorkerThreadFactory(functionLookupTable), functionCallSerializer, {maxConcurrencyLevel});
+const threadPool = new DefaultThreadPool(new BrowserWorkerThreadFactory(functionLookupTable), { maxConcurrencyLevel });
 
 /**
  * The global parallel instance.
  */
-const parallel: IParallel = parallelFactory({ maxConcurrencyLevel, scheduler: new DefaultParallelScheduler(), threadPool });
+const parallel: IParallel = parallelFactory({
+    functionCallSerializer,
+    maxConcurrencyLevel,
+    scheduler: new DefaultParallelScheduler(),
+    threadPool
+});
 export default parallel;

--- a/src/common/parallel/parallel-options.ts
+++ b/src/common/parallel/parallel-options.ts
@@ -5,11 +5,18 @@
 
 import {IThreadPool} from "../thread-pool/thread-pool";
 import {IParallelJobScheduler} from "./scheduling/parallel-job-scheduler";
+import {FunctionCallSerializer} from "../function/function-call-serializer";
 
 /**
  * Options that affect how a parallel operation is executed.
  */
 export interface IParallelOptions {
+
+    /**
+     * Serializer used to serialize {@link FunctionCall}s
+     */
+    functionCallSerializer?: FunctionCallSerializer;
+
     /**
      * Maximum number of workers that can run in parallel (without blocking each other)
      */
@@ -41,6 +48,7 @@ export interface IParallelOptions {
  * Initialized parallel options
  */
 export interface IDefaultInitializedParallelOptions extends IParallelOptions {
+    functionCallSerializer: FunctionCallSerializer;
     maxConcurrencyLevel: number;
     threadPool: IThreadPool;
     scheduler: IParallelJobScheduler;

--- a/src/common/parallel/scheduling/abstract-parallel-scheduler.ts
+++ b/src/common/parallel/scheduling/abstract-parallel-scheduler.ts
@@ -13,7 +13,7 @@ import {isSerializedFunctionCall} from "../../function/serialized-function-call"
 export abstract class AbstractParallelScheduler implements IParallelJobScheduler {
     public schedule<TResult>(job: IParallelJob): ITask<TResult>[] {
         const taskDefinitions = this.getTaskDefinitions(job);
-        return taskDefinitions.map(taskDefinition => job.options.threadPool.runTask(taskDefinition));
+        return taskDefinitions.map(taskDefinition => job.options.threadPool.run(taskDefinition));
     }
 
     /**
@@ -25,7 +25,7 @@ export abstract class AbstractParallelScheduler implements IParallelJobScheduler
 
     private getTaskDefinitions(job: IParallelJob): ITaskDefinition[] {
         const scheduling = this.getScheduling(job.generator.length, job.options);
-        const functionCallSerializer = job.options.threadPool.getFunctionSerializer();
+        const functionCallSerializer = job.options.functionCallSerializer;
 
         const environments = job.environment.toJSON(functionCallSerializer);
         const operations = this.serializeOperations(job.operations, functionCallSerializer);

--- a/src/common/thread-pool/thread-pool.ts
+++ b/src/common/thread-pool/thread-pool.ts
@@ -5,8 +5,6 @@
 
 import {ITask} from "../task/task";
 import {ITaskDefinition} from "../task/task-definition";
-import {FunctionCallSerializer} from "../function/function-call-serializer";
-import {IFunctionId} from "../function/function-id";
 
 /**
  * The thread pool is responsible for distributing the scheduled tasks onto different workers. The thread pool defines how the
@@ -15,114 +13,8 @@ import {IFunctionId} from "../function/function-id";
 export interface IThreadPool {
 
     /**
-     * Runs the passed in function on an available worker. If no worker is available, then the
-     * function is queued until another task completes and therefore a worker is released.
-     * @param func the function to execute on the worker. The function is executed in the context of a worker (no shared memory) and
-     * therefore as limited access to global variables and the dom.
-     * @param TResult the type of the result returned by the scheduled function
-     * @returns the scheduled task.
-     */
-    run<TResult>(func: (this: void) => TResult): ITask<TResult>;
-
-    /**
-     * @param param1 sole parameter that is passed to the function
-     * @param TParam1 type of the parameter passed to the function
-     */
-    run<TParam1, TResult>(func: (this: void, param1: TParam1) => TResult, param1: TParam1): ITask<TResult>;
-
-    /**
-     * @param param1 the first parameter that is passed to the scheduled function
-     * @param TParam1 type of the first parameter
-     * @param param2 the second parameter that is passed to the scheduled function
-     * @param TParam2 type of the second function parameter
-     */
-    run<TParam1, TParam2, TResult>(func: (this: void, param1: TParam1, param2: TParam2) => TResult, param1: TParam1, param2: TParam2): ITask<TResult>;
-
-    /**
-     * @param param1 the first parameter that is passed to the scheduled function
-     * @param TParam1 type of the first parameter
-     * @param param2 the second parameter that is passed to the scheduled function
-     * @param TParam2 type of the second function parameter
-     * @param param3 the third parameter that is passed to the scheduled function
-     * @param TParam3 type of the third function parameter
-     */
-    run<TParam1, TParam2, TParam3, TResult>(func: (this: void, param1: TParam1, param2: TParam2, param3: TParam3) => TResult, param1: TParam1, param2: TParam2, param3: TParam3): ITask<TResult>;
-
-    /**
-     * @param param1 the first parameter that is passed to the scheduled function
-     * @param TParam1 type of the first parameter
-     * @param param2 the second parameter that is passed to the scheduled function
-     * @param TParam2 type of the second function parameter
-     * @param param3 the third parameter that is passed to the scheduled function
-     * @param TParam3 type of the third function parameter
-     * @param param4 the fourth parameter that is passed to the scheduled function
-     * @param TParam4 type of the fourth function parameter
-     */
-    run<TParam1, TParam2, TParam3, TParam4, TResult>(func: (this: void, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4) => TResult, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4): ITask<TResult>;
-
-    /**
-     * @param param1 the first parameter that is passed to the scheduled function
-     * @param TParam1 type of the first parameter
-     * @param param2 the second parameter that is passed to the scheduled function
-     * @param TParam2 type of the second function parameter
-     * @param param3 the third parameter that is passed to the scheduled function
-     * @param TParam3 type of the third function parameter
-     * @param param4 the fourth parameter that is passed to the scheduled function
-     * @param TParam4 type of the fourth function parameter
-     * @param param5 the fifth parameter that is passed to the scheduled function
-     * @param TParam5 type of the fifth function parameter
-     */
-    run<TParam1, TParam2, TParam3, TParam4, TParam5, TResult>(func: (this: void, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4, param5: TParam5) => TResult, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4, param5: TParam5): ITask<TResult>;
-
-    /**
-     * @param param1 the first parameter that is passed to the scheduled function
-     * @param TParam1 type of the first parameter
-     * @param param2 the second parameter that is passed to the scheduled function
-     * @param TParam2 type of the second function parameter
-     * @param param3 the third parameter that is passed to the scheduled function
-     * @param TParam3 type of the third function parameter
-     * @param param4 the fourth parameter that is passed to the scheduled function
-     * @param TParam4 type of the fourth function parameter
-     * @param param5 the fifth parameter that is passed to the scheduled function
-     * @param TParam5 type of the fifth function parameter
-     * @param param6 the sixth parameter that is passed to the scheduled function
-     * @param TParam6 type of the sixth function parameter
-     */
-    run<TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, TResult>(func: (this: void, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4, param5: TParam5, param6: TParam6) => TResult, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4, param5: TParam5, param6: TParam6): ITask<TResult>;
-
-    /**
-     * @param param1 the first parameter that is passed to the scheduled function
-     * @param TParam1 type of the first parameter
-     * @param param2 the second parameter that is passed to the scheduled function
-     * @param TParam2 type of the second function parameter
-     * @param param3 the third parameter that is passed to the scheduled function
-     * @param TParam3 type of the third function parameter
-     * @param param4 the fourth parameter that is passed to the scheduled function
-     * @param TParam4 type of the fourth function parameter
-     * @param param5 the fifth parameter that is passed to the scheduled function
-     * @param TParam5 type of the fifth function parameter
-     * @param param6 the sixth parameter that is passed to the scheduled function
-     * @param TParam6 type of the sixth function parameter
-     * @param furtherParams further params that are passed to the scheduled function
-     */
-    run<TParam1, TParam2, TParam3, TParam4, TParam5, TParam6, TResult>(func: (this: void, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4, param5: TParam5, param6: TParam6, ...furtherParams: any[]) => TResult, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4, param5: TParam5, param6: TParam6, ...furtherParams: any[]): ITask<TResult>;
-
-    /**
-     * Schedules the function with the given id
-     * @param func the id of the function
-     * @param params the params to pass to the function
-     */
-    run<TResult>(func: IFunctionId, ...params: any[]): ITask<TResult>;
-
-    /**
      * Schedules the passed in task definition onto an available worker or enqueues the task to be scheduled as soon as a worker gets available.
      * @param task the task to schedule
      */
-    runTask<TResult>(task: ITaskDefinition): ITask<TResult>;
-
-    /**
-     * returns the function serializer that can be used to serialize function calls.
-     * @returns a new function serializer
-     */
-    getFunctionSerializer(): FunctionCallSerializer;
+    run<TResult>(task: ITaskDefinition): ITask<TResult>;
 }

--- a/test/common/parallel/chain/dependent-parallel-chain-state.specs.ts
+++ b/test/common/parallel/chain/dependent-parallel-chain-state.specs.ts
@@ -20,6 +20,7 @@ describe("DependentParallelChainState", function () {
         scheduler = jasmine.createSpyObj<IParallelJobScheduler>("scheduler", ["schedule"]);
         scheduleSpy = scheduler.schedule as jasmine.Spy;
         options = {
+            functionCallSerializer: undefined as any,
              maxConcurrencyLevel: 2,
              scheduler,
              threadPool: undefined as any

--- a/test/common/parallel/chain/parallel-chain-factory.specs.ts
+++ b/test/common/parallel/chain/parallel-chain-factory.specs.ts
@@ -17,6 +17,7 @@ describe("createParallelChain", function () {
     beforeEach(function () {
         generator = new ParallelCollectionGenerator([1, 2, 3, 4]);
         options = {
+            functionCallSerializer: undefined as any,
             maxConcurrencyLevel: 2,
             scheduler: undefined as any,
             threadPool: undefined as any

--- a/test/common/parallel/chain/parallel-chain-impl.specs.ts
+++ b/test/common/parallel/chain/parallel-chain-impl.specs.ts
@@ -29,6 +29,7 @@ describe("ParallelChainImpl", function () {
         } as any;
 
         options = {
+            functionCallSerializer: undefined as any,
             maxConcurrencyLevel: 2,
             scheduler: undefined as any,
             threadPool: undefined as any

--- a/test/common/parallel/chain/pending-parallel-chain-state.specs.ts
+++ b/test/common/parallel/chain/pending-parallel-chain-state.specs.ts
@@ -20,6 +20,7 @@ describe("PendingParallelChainState", function () {
         scheduler = jasmine.createSpyObj<IParallelJobScheduler>("scheduler", ["schedule"]);
         scheduleSpy = scheduler.schedule as jasmine.Spy;
         options = {
+            functionCallSerializer: undefined as any,
             maxConcurrencyLevel: 2,
             scheduler,
             threadPool: undefined as any

--- a/test/common/parallel/chain/scheduled-parallel-chain-state.specs.ts
+++ b/test/common/parallel/chain/scheduled-parallel-chain-state.specs.ts
@@ -14,6 +14,7 @@ describe("ScheduledParallelChainState", function () {
 
     beforeEach(function () {
         options = {
+            functionCallSerializer: undefined as any,
             maxConcurrencyLevel: 2,
             scheduler: undefined as any,
             threadPool: undefined as any

--- a/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
+++ b/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
@@ -7,7 +7,7 @@ describe("DefaultParallelScheduler", function () {
 
     beforeEach(function () {
         scheduler = new DefaultParallelScheduler();
-        options = { maxConcurrencyLevel: 2, scheduler, threadPool: undefined as any };
+        options = { functionCallSerializer: undefined as any, maxConcurrencyLevel: 2, scheduler, threadPool: undefined as any };
     });
 
     describe("getScheduling", function () {


### PR DESCRIPTION
ThreadPool is an internal concept. Therefore a single run method accepting a task definition is sufficient.
Converting a function call to a task definition can be handled by the parallel facade.
