### PR TITLE
Fix parallel range generator for negative step sizes

### DIFF
--- a/src/common/parallel/generator/parallel-range-generator.ts
+++ b/src/common/parallel/generator/parallel-range-generator.ts
@@ -13,7 +13,8 @@ export class ParallelRangeGenerator implements IParallelGenerator {
      * @param start depends on the number of arguments. If called with one argument, then it is the end of the range and start is initialized with 0.
      * If called with two or more, then it defines the start of the range.
      * @param end defines the end of the range
-     * @param step defines the step size. By default 1 if start < end and -1 if start > end
+     * @param step defines the step size. By default 1 if start < end and -1 if start > end.
+     * @throws If step is equal to 0
      */
     public static create(start: number, end?: number, step?: number) {
         if (typeof(end) === "undefined") {
@@ -23,6 +24,10 @@ export class ParallelRangeGenerator implements IParallelGenerator {
 
         if (typeof step === "undefined") {
             step = end < start ? -1 : 1;
+        }
+
+        if (step === 0) {
+            throw new Error("Step size of zero is not allowed");
         }
 
         return new ParallelRangeGenerator(start, end, step);

--- a/src/common/parallel/parallel.ts
+++ b/src/common/parallel/parallel.ts
@@ -45,8 +45,9 @@ export interface IParallel {
      * Creates an array containing the elements in the range from start (inclusive) to end (exclusive) with the step size of step.
      * @param start the start of the range or the end, if the function is called with a single argument
      * @param end the end of the range
-     * @param step the step size
+     * @param step the step size.
      * @param options options configuring the computation behaviour
+     * @throws if step size is equal to zero
      */
     range(start: number, end?: number, step?: number, options?: IParallelOptions): IParallelChain<number, {}, number>;
 

--- a/src/common/parallel/slave/range-iterator.ts
+++ b/src/common/parallel/slave/range-iterator.ts
@@ -6,12 +6,15 @@
  * @returns iterator with the values [start, end)
  */
 export function rangeIterator(start: number, end: number, step: number): Iterator<number> {
+    const distance = end - start;
+    let length = Math.max(Math.floor(distance / (step || 1)), 0);
     let next = start;
+
     return {
         next(): IteratorResult<number> {
             let current = next;
-            next = current + step;
-            if (current < end) {
+            next = next + step;
+            if (length-- !== 0) {
                 return { done: false, value: current };
             }
             return { done: true } as IteratorResult<number>;

--- a/test/common/parallel/generator/parallel-range-generator.specs.ts
+++ b/test/common/parallel/generator/parallel-range-generator.specs.ts
@@ -56,6 +56,11 @@ describe("ParallelRangeGenerator", function () {
             expect(generator.end).toBe(1);
             expect(generator.step).toBe(-1);
         });
+
+        it("throws if the step size is 0", function() {
+            // act
+            expect(() => ParallelRangeGenerator.create(1, 10, 0)).toThrowError("Step size of zero is not allowed");
+        });
     });
 
     describe("length", function () {

--- a/test/common/parallel/slave/range-iterator.specs.ts
+++ b/test/common/parallel/slave/range-iterator.specs.ts
@@ -9,4 +9,28 @@ describe("rangeIterator", function () {
         // act, assert
         expect(toArray(iterator)).toEqual([10, 12, 14, 16, 18]);
     });
+
+    it("returns an iterator containing the elements from start up to end (exclusive) using a negative step size", function () {
+        // arrange
+        const iterator = rangeIterator(-10, -21, -2);
+
+        // act, assert
+        expect(toArray(iterator)).toEqual([-10, -12, -14, -16, -18]);
+    });
+
+    it("returns an iterator containing the elements from start up to end (exclusive) if the step size is fractional", function () {
+        // arrange
+        const iterator = rangeIterator(0, 1, 0.1);
+
+        // act, assert
+        expect(toArray(iterator)).toEqual([0, 0.1, 0.2, 0.30000000000000004, 0.4, 0.5, 0.6, 0.7, 0.7999999999999999, 0.8999999999999999]);
+    });
+
+    it("returns an empty iterator if step size is negative and end is larger than start", function () {
+        // arrange
+        const iterator = rangeIterator(10, 15, -1);
+
+        // act, assert
+        expect(toArray(iterator)).toEqual([]);
+    });
 });


### PR DESCRIPTION
The existing implementation only supported positive step sizes (end > start). Fix the implementation for negative step sizes (end < start).
