### PR TITLE
Reduce Memory Requirements

### DIFF
--- a/src/common/parallel/chain/dependent-parallel-chain-state.ts
+++ b/src/common/parallel/chain/dependent-parallel-chain-state.ts
@@ -3,7 +3,7 @@ import {IParallelOperation, IDefaultInitializedParallelOptions} from "../";
 import {IParallelStream} from "../stream/parallel-stream";
 import {ScheduledParallelChainState} from "./scheduled-parallel-chain-state";
 import {ParallelCollectionGenerator} from "../generator/parallel-collection-generator";
-import {flattenArray} from "../../util/arrays";
+import {concatInPlace} from "../../util/arrays";
 import {ParallelStream} from "../stream/parallel-stream-impl";
 import {ParallelEnvironmentDefinition} from "../parallel-environment-definition";
 
@@ -46,7 +46,7 @@ export class DependentParallelChainState<TPrevious, TElement> implements IParall
                 options: this.options
             });
 
-            const wrappedStream = ParallelStream.fromTasks(tasks, flattenArray);
+            const wrappedStream = ParallelStream.fromTasks(tasks, [], concatInPlace);
             wrappedStream.subscribe(next!, reject!, resolve!);
         }, reject!);
 

--- a/src/common/parallel/chain/pending-parallel-chain-state.ts
+++ b/src/common/parallel/chain/pending-parallel-chain-state.ts
@@ -3,7 +3,7 @@ import {ScheduledParallelChainState} from "./scheduled-parallel-chain-state";
 import {IParallelGenerator} from "../generator/parallel-generator";
 import {IParallelOperation, IDefaultInitializedParallelOptions} from "../";
 import {ParallelStream} from "../stream/parallel-stream-impl";
-import {flattenArray} from "../../util/arrays";
+import {concatInPlace} from "../../util/arrays";
 import {ParallelEnvironmentDefinition} from "../parallel-environment-definition";
 
 /**
@@ -41,7 +41,7 @@ export class PendingParallelChainState<TElement> implements IParallelChainState<
             options: this.options
         });
 
-        return new ScheduledParallelChainState<TElement>(ParallelStream.fromTasks(tasks, flattenArray), this.options, this.environment);
+        return new ScheduledParallelChainState<TElement>(ParallelStream.fromTasks(tasks, [], concatInPlace), this.options, this.environment);
     }
 
     public chainOperation<TElementNew>(operation: IParallelOperation): IParallelChainState<TElementNew> {

--- a/src/common/parallel/stream/parallel-stream-impl.ts
+++ b/src/common/parallel/stream/parallel-stream-impl.ts
@@ -70,17 +70,18 @@ export class ParallelStream<TSubResult, TEndResult> implements IParallelStream<T
     /**
      * Creates a new parallel stream for the given set of tasks.
      * @param tasks the set of tasks that compute the results of the stream
-     * @param joiner the joiner to use to join the computed results of the stream
+     * @param defaultResult the default result
+     * @param joiner the joiner to use to join two computed task results
      * @param TTaskResult type of the task results
      * @param TEndResult result of the created stream. Created by applying the end results of the stream to the joiner
      * @returns stream for the given set of tasks
      */
-    public static fromTasks<TTaskResult, TEndResult>(tasks: ITask<TTaskResult>[], joiner: (subResults: TTaskResult[]) => TEndResult): IParallelStream<TTaskResult, TEndResult> {
+    public static fromTasks<TTaskResult, TEndResult>(tasks: ITask<TTaskResult>[], defaultResult: TEndResult, joiner: (memo: TTaskResult, current: TTaskResult) => TEndResult): IParallelStream<TTaskResult, TEndResult> {
         if (tasks.length === 0) {
-            return new ResolvedParallelStream(joiner.apply(undefined, [[]]));
+            return new ResolvedParallelStream(defaultResult);
         }
 
-        return new ScheduledParallelStream(tasks, joiner);
+        return new ScheduledParallelStream(tasks, defaultResult, joiner);
     }
 
     private promise: Promise<TEndResult>;

--- a/src/common/util/arrays.ts
+++ b/src/common/util/arrays.ts
@@ -38,3 +38,14 @@ export function flattenArray<T>(deepArray: T[][]): T[] {
     const [head, ...tail] = deepArray;
     return Array.prototype.concat.apply(head, tail);
 }
+
+export function concatInPlace<T>(target: T[], toAppend: T[]): T[] {
+    const insertionIndex = target.length;
+    target.length += toAppend.length;
+
+    for (let i = 0; i < toAppend.length; ++i) {
+        target[insertionIndex + i] = toAppend[i];
+    }
+
+    return target;
+}

--- a/test/common/parallel/stream/parallel-stream-impl.specs.ts
+++ b/test/common/parallel/stream/parallel-stream-impl.specs.ts
@@ -2,7 +2,7 @@ import {ParallelStream} from "../../../../src/common/parallel/stream/parallel-st
 import {ResolvedParallelStream} from "../../../../src/common/parallel/stream/resolved-parallel-stream";
 import {ITask} from "../../../../src/common/task/task";
 import {ScheduledParallelStream} from "../../../../src/common/parallel/stream/scheduled-parallel-stream";
-describe("ParallelStream", function () {
+describe("ParallelStreamImpl", function () {
     let next: ((subResult: string, worker: number, valuesPerWorker: number) => void) | undefined = undefined;
     let reject: ((reason: any) => void) | undefined = undefined;
     let resolve: ((result: number) => void) | undefined = undefined;
@@ -61,18 +61,21 @@ describe("ParallelStream", function () {
     describe("fromTasks", function () {
         it("returns a resolved parallel stream if the task array is empty", function () {
              // act
-            const result = ParallelStream.fromTasks([], () => "abcd");
+            const result = ParallelStream.fromTasks([], "", () => "abcd");
 
             // assert
             expect(result).toEqual(jasmine.any(ResolvedParallelStream));
         });
 
-        it("applies the joiner to an empty array if the task array is empty", function () {
+        it("returns the default value if the task array is empty", function (done) {
             // act
-            const result = ParallelStream.fromTasks([], () => "abcd");
+            const result = ParallelStream.fromTasks([], "ab", () => "abcd");
 
             // assert
-            result.then(res => expect(res).toEqual("abcd"));
+            result.then(res => {
+                expect(res).toEqual("ab");
+                done();
+            });
         });
 
         it("returns a scheduled parallel stream if the task array is not empty", function () {
@@ -80,7 +83,7 @@ describe("ParallelStream", function () {
             const tasks: ITask<string[]>[] = [ jasmine.createSpyObj("task", ["then"]) ];
 
             // act
-            const result = ParallelStream.fromTasks(tasks, () => "abcd");
+            const result = ParallelStream.fromTasks(tasks, "", () => "abcd");
 
             // assert
             expect(result).toEqual(jasmine.any(ScheduledParallelStream));

--- a/test/common/parallel/stream/scheduled-parallel-stream.specs.ts
+++ b/test/common/parallel/stream/scheduled-parallel-stream.specs.ts
@@ -8,7 +8,13 @@ describe("ScheduledParallelStream", function () {
     let task1: FakeTask<string>;
     let task2: FakeTask<string>;
     let task3: FakeTask<string>;
-    let joiner = (values: string[]) => values.join(" ");
+    let joiner = (first: string, second: string) => {
+        if (typeof first === "undefined") {
+            return second;
+        }
+
+        return first + " " + second;
+    };
 
     beforeEach(function () {
         tasks = [new FakeTask(0), new FakeTask(1), new FakeTask(2)];
@@ -18,7 +24,7 @@ describe("ScheduledParallelStream", function () {
     describe("subscribe", function () {
         it("calls the onNext handler for every resolved sub result", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
             const onNextSpy = jasmine.createSpy("onNext");
             stream.subscribe(onNextSpy);
 
@@ -39,7 +45,7 @@ describe("ScheduledParallelStream", function () {
 
         it("passes the correct task index even if the tasks are resolved out of order", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
             const onNextSpy = jasmine.createSpy("onNext");
             stream.subscribe(onNextSpy);
 
@@ -60,7 +66,7 @@ describe("ScheduledParallelStream", function () {
 
         it("does not trigger the onNext callback after the first task has failed (fail fast)", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
             const onNextSpy = jasmine.createSpy("onNext");
             stream.subscribe(onNextSpy);
 
@@ -79,7 +85,7 @@ describe("ScheduledParallelStream", function () {
 
         it("multiple onNext handlers can be registered", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
             const onNextSpy = jasmine.createSpy("onNext");
             const onNextSpy2 = jasmine.createSpy("onNext2");
             stream.subscribe(onNextSpy);
@@ -101,7 +107,7 @@ describe("ScheduledParallelStream", function () {
 
         it("The onError callback is called if a task fails", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
             const onNextSpy = jasmine.createSpy("onNext");
             const onError = jasmine.createSpy("onError");
             stream.subscribe(onNextSpy, onError);
@@ -118,7 +124,7 @@ describe("ScheduledParallelStream", function () {
 
         it("Calls the onComplete handler if all tasks have been completed", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
             const onNextSpy = jasmine.createSpy("onNext");
             const onError = jasmine.createSpy("onError");
             const onComplete = jasmine.createSpy("onComplete");
@@ -141,7 +147,7 @@ describe("ScheduledParallelStream", function () {
     describe("then", function () {
         it("calls the onFulfilled handler if all tasks have been completed", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
             const onFulfilled = jasmine.createSpy("onFulfilled");
             const completed = stream.then(onFulfilled);
 
@@ -162,7 +168,7 @@ describe("ScheduledParallelStream", function () {
 
         it("calls the onRejected handler if any tasks failed", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
 
             // act
             task1.resolve("Good");
@@ -197,7 +203,7 @@ describe("ScheduledParallelStream", function () {
 
         it("calls the onrejected handler if any task failed", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
 
             // act
             task1.resolve("Good");
@@ -217,7 +223,7 @@ describe("ScheduledParallelStream", function () {
 
         it("cancels all not yet completed tasks", function (done) {
             // arrange
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
 
             // act
             task1.resolve("Good");
@@ -239,7 +245,7 @@ describe("ScheduledParallelStream", function () {
             // arrange
             doneFn = done;
 
-            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, joiner);
+            const stream: IParallelStream<string, string> = new ScheduledParallelStream(tasks, undefined, joiner);
             stream.catch(() => done());
 
             // act

--- a/test/common/util/arrays.specs.ts
+++ b/test/common/util/arrays.specs.ts
@@ -1,4 +1,5 @@
-import {toIterator, toArray, flattenArray} from "../../../src/common/util/arrays";
+import {toIterator, toArray, flattenArray, concatInPlace} from "../../../src/common/util/arrays";
+
 describe("arrays", function () {
     describe("toIterator", function () {
         it("returns an iterator with a next method", function () {
@@ -89,4 +90,29 @@ describe("arrays", function () {
             expect(flattenArray([[1, 2], [3, 4]])).toEqual([1, 2, 3, 4]);
         });
     });
+
+    describe("concatInPlace", function () {
+        it("returns an empty array if two empty arrays are concatenated", function () {
+            // arrange
+            const target: number[] = [];
+
+            // act
+            concatInPlace(target, []);
+
+            // assert
+            expect(target).toEqual([]);
+        });
+
+        it("inserts the elements of the second array into the first", function () {
+            // arrange
+            const target = [1, 2];
+
+            // act
+            concatInPlace(target, [3, 4, 5]);
+
+            // assert
+            expect(target).toEqual([1, 2, 3, 4, 5]);
+        });
+    });
+
 });


### PR DESCRIPTION
The memory requirements in the worst Case are still O(2N) since all sub results are copied into the results array. However, as long as the tasks almost complete sequentially, the memory consumption should be far less than 2n. This is achieved by sequentially joining the sub results instead of joining the end results in one step. If the results arrive strictly sequentially, than the memory requirements are O(N+1).