### PR TITLE
Add oversubscribe option

### DIFF
--- a/src/api/browser.ts
+++ b/src/api/browser.ts
@@ -25,6 +25,7 @@ const threadPool = new DefaultThreadPool(new BrowserWorkerThreadFactory(function
 const parallel: IParallel = parallelFactory({
     functionCallSerializer,
     maxConcurrencyLevel,
+    oversubscribe: true,
     scheduler: new DefaultParallelScheduler(),
     threadPool
 });

--- a/src/common/parallel/parallel-options.ts
+++ b/src/common/parallel/parallel-options.ts
@@ -42,6 +42,15 @@ export interface IParallelOptions {
      * The scheduler that should be used to determine the number of tasks to create.
      */
     scheduler?: IParallelJobScheduler;
+
+    /**
+     * Allow the {@link IParallelOptions.scheduler} to create more than {@link IParallelOptions.maxConcurrency} tasks
+     * for a single job. By default this is desired but might increases computation time if the initialization of the environment
+     * is very compute intensive (compared to the computation needed to transform the elements).
+     * This option is only a hint for the scheduler. Actual implementations may ignore the option at all or interpret it less strict.
+     * @default true
+     */
+    oversubscribe?: boolean;
 }
 
 /**
@@ -52,4 +61,5 @@ export interface IDefaultInitializedParallelOptions extends IParallelOptions {
     maxConcurrencyLevel: number;
     threadPool: IThreadPool;
     scheduler: IParallelJobScheduler;
+    oversubscribe: boolean;
 }

--- a/src/common/parallel/scheduling/default-parallel-scheduler.ts
+++ b/src/common/parallel/scheduling/default-parallel-scheduler.ts
@@ -11,7 +11,8 @@ import {AbstractParallelScheduler, IParallelTaskScheduling} from "./abstract-par
 export class DefaultParallelScheduler extends AbstractParallelScheduler {
 
     public getScheduling(totalNumberOfValues: number, options: IDefaultInitializedParallelOptions): IParallelTaskScheduling {
-        let itemsPerTask = totalNumberOfValues / (options.maxConcurrencyLevel * 4);
+        const maxNumberOfTasks = options.oversubscribe === false ? options.maxConcurrencyLevel : options.maxConcurrencyLevel * 4;
+        let itemsPerTask = totalNumberOfValues / maxNumberOfTasks;
 
         if (options.minValuesPerTask) {
             itemsPerTask = Math.min(Math.max(itemsPerTask, options.minValuesPerTask), totalNumberOfValues);

--- a/test/common/parallel/chain/dependent-parallel-chain-state.specs.ts
+++ b/test/common/parallel/chain/dependent-parallel-chain-state.specs.ts
@@ -21,9 +21,10 @@ describe("DependentParallelChainState", function () {
         scheduleSpy = scheduler.schedule as jasmine.Spy;
         options = {
             functionCallSerializer: undefined as any,
-             maxConcurrencyLevel: 2,
-             scheduler,
-             threadPool: undefined as any
+            maxConcurrencyLevel: 2,
+            oversubscribe: true,
+            scheduler,
+            threadPool: undefined as any
         };
 
         environment = ParallelEnvironmentDefinition.of();

--- a/test/common/parallel/chain/parallel-chain-factory.specs.ts
+++ b/test/common/parallel/chain/parallel-chain-factory.specs.ts
@@ -19,6 +19,7 @@ describe("createParallelChain", function () {
         options = {
             functionCallSerializer: undefined as any,
             maxConcurrencyLevel: 2,
+            oversubscribe: true,
             scheduler: undefined as any,
             threadPool: undefined as any
         };

--- a/test/common/parallel/chain/parallel-chain-impl.specs.ts
+++ b/test/common/parallel/chain/parallel-chain-impl.specs.ts
@@ -31,6 +31,7 @@ describe("ParallelChainImpl", function () {
         options = {
             functionCallSerializer: undefined as any,
             maxConcurrencyLevel: 2,
+            oversubscribe: true,
             scheduler: undefined as any,
             threadPool: undefined as any
         };

--- a/test/common/parallel/chain/pending-parallel-chain-state.specs.ts
+++ b/test/common/parallel/chain/pending-parallel-chain-state.specs.ts
@@ -22,6 +22,7 @@ describe("PendingParallelChainState", function () {
         options = {
             functionCallSerializer: undefined as any,
             maxConcurrencyLevel: 2,
+            oversubscribe: true,
             scheduler,
             threadPool: undefined as any
         };

--- a/test/common/parallel/chain/scheduled-parallel-chain-state.specs.ts
+++ b/test/common/parallel/chain/scheduled-parallel-chain-state.specs.ts
@@ -16,6 +16,7 @@ describe("ScheduledParallelChainState", function () {
         options = {
             functionCallSerializer: undefined as any,
             maxConcurrencyLevel: 2,
+            oversubscribe: true,
             scheduler: undefined as any,
             threadPool: undefined as any
         };

--- a/test/common/parallel/parallel-impl.specs.ts
+++ b/test/common/parallel/parallel-impl.specs.ts
@@ -34,6 +34,7 @@ describe("Parallel", function () {
         options = {
             functionCallSerializer,
             maxConcurrencyLevel,
+            oversubscribe: true,
             threadPool,
             scheduler: undefined as any
         };
@@ -148,6 +149,7 @@ describe("Parallel", function () {
                 functionCallSerializer,
                 maxConcurrencyLevel,
                 maxValuesPerTask: 2,
+                oversubscribe: true,
                 threadPool,
                 scheduler: undefined
             });
@@ -174,6 +176,7 @@ describe("Parallel", function () {
                 functionCallSerializer,
                 maxConcurrencyLevel,
                 maxValuesPerTask: 2,
+                oversubscribe: true,
                 threadPool,
                 scheduler: undefined
             });
@@ -202,6 +205,7 @@ describe("Parallel", function () {
                 functionCallSerializer,
                 maxConcurrencyLevel,
                 maxValuesPerTask: 2,
+                oversubscribe: true,
                 threadPool,
                 scheduler: undefined
             }, {});

--- a/test/common/parallel/scheduling/abstract-parallel-scheduler.specs.ts
+++ b/test/common/parallel/scheduling/abstract-parallel-scheduler.specs.ts
@@ -40,6 +40,7 @@ describe("AbstractParallelScheduler", function () {
         options = {
             functionCallSerializer: functionSerializer,
             maxConcurrencyLevel: 2,
+            oversubscribe: true,
             scheduler,
             threadPool
         };

--- a/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
+++ b/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
@@ -7,7 +7,13 @@ describe("DefaultParallelScheduler", function () {
 
     beforeEach(function () {
         scheduler = new DefaultParallelScheduler();
-        options = { functionCallSerializer: undefined as any, maxConcurrencyLevel: 2, scheduler, threadPool: undefined as any };
+        options = {
+            functionCallSerializer: undefined as any,
+            maxConcurrencyLevel: 2,
+            oversubscribe: true,
+            scheduler,
+            threadPool: undefined as any
+        };
     });
 
     describe("getScheduling", function () {
@@ -74,6 +80,18 @@ describe("DefaultParallelScheduler", function () {
             // assert
             expect(scheduling.valuesPerTask).toBe(0);
             expect(scheduling.numberOfTasks).toBe(0);
+        });
+
+        it("sets valuesPerTask not larger than options.maxConcurrencyLevel if oversubscribe is false", function () {
+            // arrange
+            options.oversubscribe = false;
+
+            // act
+            const scheduling = scheduler.getScheduling(20, options);
+
+            // assert
+            expect(scheduling.numberOfTasks).toBe(2);
+            expect(scheduling.valuesPerTask).toBe(10);
         });
     });
 });


### PR DESCRIPTION
Add an oversubscribe option that gives the parallel scheduler a hint if it is allowed to spawn more than maxConcurrencyLevel tasks or not.
True by default to achieve better performance for non linear problems.