### PR TITLE
Make maxDegreeOfParallelism an absolut value

### DIFF
--- a/src/common/parallel/parallel-options.ts
+++ b/src/common/parallel/parallel-options.ts
@@ -45,11 +45,8 @@ export interface IParallelOptions {
 
     /**
      * Defines the max degree of parallelism to use for a scheduled job. The value defines in how many task the scheduler is allowed
-     * to split the task at most relative to the {@link IParallelOptions.maxConcurrency}. If the value is equal to one, at most
-     * as many tasks as {@link IParallelOptions.maxConcurrency} are created. If the value is larger than one, than {@link IParallelOptions.maxDegreeOfParallelism} as
-     * many tasks are created (at most). Negative values or a value of zero is not allowed. If the value is in between (0, 1) than scheduler
-     * guarantees that at least one task is created. If the value is undefined, the scheduler is free to choose the desired
-     * degree of parallelism
+     * to split the task at most. A value of 1 creates exactly one task. Undefined does not limit the max degree and leaves it to the
+     * scheduler to decide.
      * @default undefined / unlimited
      */
     maxDegreeOfParallelism?: number;
@@ -67,6 +64,9 @@ export interface IDefaultInitializedParallelOptions extends IParallelOptions {
 
 const greaterThanZeroOptions = ["maxValuesPerTask", "minValuesPerTask", "maxConcurrencyLevel", "maxDegreeOfParallelism"];
 export function validateOptions(options: IParallelOptions) {
+    if (typeof (options.maxDegreeOfParallelism) === "number") {
+        options.maxDegreeOfParallelism = Math.floor(options.maxDegreeOfParallelism);
+    }
 
     for (const optionName of greaterThanZeroOptions) {
         const optionValue = (options as {[name: string]: number | undefined })[optionName];

--- a/src/common/parallel/scheduling/default-parallel-scheduler.ts
+++ b/src/common/parallel/scheduling/default-parallel-scheduler.ts
@@ -11,15 +11,15 @@ import {AbstractParallelScheduler, IParallelTaskScheduling} from "./abstract-par
 export class DefaultParallelScheduler extends AbstractParallelScheduler {
 
     public getScheduling(totalNumberOfValues: number, options: IDefaultInitializedParallelOptions): IParallelTaskScheduling {
-        let maxNumberOfTasks: number;
+        let maxDegreeOfParallelism: number;
 
         if (options.maxDegreeOfParallelism) {
-            maxNumberOfTasks = Math.ceil(options.maxConcurrencyLevel * options.maxDegreeOfParallelism);
+            maxDegreeOfParallelism = options.maxDegreeOfParallelism;
         } else {
-            maxNumberOfTasks = options.maxConcurrencyLevel * 4;
+            maxDegreeOfParallelism = options.maxConcurrencyLevel * 4;
         }
 
-        let itemsPerTask = totalNumberOfValues / maxNumberOfTasks;
+        let itemsPerTask = totalNumberOfValues / maxDegreeOfParallelism;
 
         if (options.minValuesPerTask) {
             itemsPerTask = Math.min(Math.max(itemsPerTask, options.minValuesPerTask), totalNumberOfValues);

--- a/test/common/parallel/parallel-options.specs.ts
+++ b/test/common/parallel/parallel-options.specs.ts
@@ -16,6 +16,18 @@ describe("validateOptions", function () {
         })).toThrowError("Illegal parallel options: minValuesPerTask (4) must be equal or less than maxValuesPerTask (2).");
     });
 
+    it("ensures that maxDegreeOfParallelism is an int", function () {
+        const options = ({
+            maxDegreeOfParallelism: 2.3
+        });
+
+        // act
+        validateOptions(options);
+
+        // assert
+        expect(options.maxDegreeOfParallelism).toBe(2);
+    });
+
     for (const option of ["maxConcurrencyLevel", "maxDegreeOfParallelism", "maxValuesPerTask", "minValuesPerTask"]) {
         it(`throws if ${option} is not a number`, function () {
             expect(() => validateOptions({

--- a/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
+++ b/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
@@ -81,9 +81,9 @@ describe("DefaultParallelScheduler", function () {
             expect(scheduling.numberOfTasks).toBe(0);
         });
 
-        it("creates at most options.maxConcurrencyLevel tasks if maxDegreeOfParallelism is equal to 1", function () {
+        it("creates at most maxDegreeOfParallelism tasks if specified", function () {
             // arrange
-            options.maxDegreeOfParallelism = 1;
+            options.maxDegreeOfParallelism = 2;
 
             // act
             const scheduling = scheduler.getScheduling(20, options);
@@ -91,30 +91,6 @@ describe("DefaultParallelScheduler", function () {
             // assert
             expect(scheduling.numberOfTasks).toBe(2);
             expect(scheduling.valuesPerTask).toBe(10);
-        });
-
-        it("creates at at least one task tasks if maxConcurrencyLevel * maxDegreeOfParallelism is less than 0.5", function () {
-            // arrange
-            options.maxDegreeOfParallelism = 0.4;
-
-            // act
-            const scheduling = scheduler.getScheduling(20, options);
-
-            // assert
-            expect(scheduling.numberOfTasks).toBe(1);
-            expect(scheduling.valuesPerTask).toBe(20);
-        });
-
-        it("rounds up if options.maxConcurrencyLevel * maxDegreeOfParallelism is fractional", function () {
-            // arrange
-            options.maxDegreeOfParallelism = 3;
-
-            // act
-            const scheduling = scheduler.getScheduling(18, options);
-
-            // assert
-            expect(scheduling.numberOfTasks).toBe(6);
-            expect(scheduling.valuesPerTask).toBe(3);
         });
     });
 });


### PR DESCRIPTION
An absolut value is easier to handle. if a relative value is desired, the maxConcurrencyLevel can be queried and used. E.g. 

```js
const options = initializeOptions(userOptions);
    return parallel
        .from(options.projects, { minValuesPerTask: 2, maxDegreeOfParallelism: parallel.defaultOptions().maxConcurrencyLevel })
        .inEnvironment(createMonteCarloEnvironment, options)
        .map(calculateProject);
```