### PR TITLE
Move maxConcurrencyLevel to ThreadPool Only

### DIFF
--- a/src/api/browser.ts
+++ b/src/api/browser.ts
@@ -24,7 +24,6 @@ const threadPool = new DefaultThreadPool(new BrowserWorkerThreadFactory(function
  */
 const parallel: IParallel = parallelFactory({
     functionCallSerializer,
-    maxConcurrencyLevel,
     scheduler: new DefaultParallelScheduler(),
     threadPool
 });

--- a/src/common/parallel/parallel-impl.ts
+++ b/src/common/parallel/parallel-impl.ts
@@ -21,10 +21,6 @@ export function parallelFactory(defaultOptions: IDefaultInitializedParallelOptio
                 throw new Error("The function call serializer is mandatory and cannot be unset");
             }
 
-            if (userOptions.hasOwnProperty("maxConcurrencyLevel") && typeof(userOptions.maxConcurrencyLevel) !== "number") {
-                throw new Error("The maxConcurrencyLevel is mandatory and has to be a number");
-            }
-
             validateOptions(userOptions);
         }
 

--- a/src/common/parallel/parallel-options.ts
+++ b/src/common/parallel/parallel-options.ts
@@ -18,11 +18,6 @@ export interface IParallelOptions {
     functionCallSerializer?: FunctionCallSerializer;
 
     /**
-     * Maximum number of workers that can run in parallel (without blocking each other)
-     */
-    maxConcurrencyLevel?: number;
-
-    /**
      * The minimum number of values assigned to a single task before the work is split and assigned another task
      */
     minValuesPerTask?: number;
@@ -57,21 +52,16 @@ export interface IParallelOptions {
  */
 export interface IDefaultInitializedParallelOptions extends IParallelOptions {
     functionCallSerializer: FunctionCallSerializer;
-    maxConcurrencyLevel: number;
     threadPool: IThreadPool;
     scheduler: IParallelJobScheduler;
 }
 
-const greaterThanZeroOptions = ["maxValuesPerTask", "minValuesPerTask", "maxConcurrencyLevel", "maxDegreeOfParallelism"];
+const greaterThanZeroOptions = ["maxValuesPerTask", "minValuesPerTask", "maxDegreeOfParallelism"];
 export function validateOptions(options: IParallelOptions) {
-    if (typeof (options.maxDegreeOfParallelism) === "number") {
-        options.maxDegreeOfParallelism = Math.floor(options.maxDegreeOfParallelism);
-    }
-
     for (const optionName of greaterThanZeroOptions) {
         const optionValue = (options as {[name: string]: number | undefined })[optionName];
-        if (typeof (optionValue) !== "undefined" && (typeof(optionValue) !== "number" || optionValue <= 0)) {
-            throw new Error(`Illegal parallel options: ${optionName} (${optionValue}) must be number greater than zero`);
+        if (typeof (optionValue) !== "undefined" && (typeof(optionValue) !== "number" || optionValue <= 0 || optionValue % 1 !== 0)) {
+            throw new Error(`Illegal parallel options: ${optionName} (${optionValue}) has to be an integer greater than zero`);
         }
     }
 

--- a/src/common/parallel/scheduling/default-parallel-scheduler.ts
+++ b/src/common/parallel/scheduling/default-parallel-scheduler.ts
@@ -16,7 +16,7 @@ export class DefaultParallelScheduler extends AbstractParallelScheduler {
         if (options.maxDegreeOfParallelism) {
             maxDegreeOfParallelism = options.maxDegreeOfParallelism;
         } else {
-            maxDegreeOfParallelism = options.maxConcurrencyLevel * 4;
+            maxDegreeOfParallelism = options.threadPool.maxThreads * 4;
         }
 
         let itemsPerTask = totalNumberOfValues / maxDegreeOfParallelism;

--- a/src/common/thread-pool/thread-pool.ts
+++ b/src/common/thread-pool/thread-pool.ts
@@ -11,6 +11,12 @@ import {ITaskDefinition} from "../task/task-definition";
  * queued tasks are scheduled onto the available workers and how many workers are created.
  */
 export interface IThreadPool {
+    /**
+     * Maximum number of threads that the thread pool should scheduled. Default initialized with the
+     * number of the hardware concurrency supported by the hardware.
+     * The value cannot be negative or 0
+     */
+    maxThreads: number;
 
     /**
      * Schedules the passed in task definition onto an available worker or enqueues the task to be scheduled as soon as a worker gets available.

--- a/test/common/parallel/chain/dependent-parallel-chain-state.specs.ts
+++ b/test/common/parallel/chain/dependent-parallel-chain-state.specs.ts
@@ -21,7 +21,6 @@ describe("DependentParallelChainState", function () {
         scheduleSpy = scheduler.schedule as jasmine.Spy;
         options = {
             functionCallSerializer: undefined as any,
-            maxConcurrencyLevel: 2,
             scheduler,
             threadPool: undefined as any
         };

--- a/test/common/parallel/chain/parallel-chain-factory.specs.ts
+++ b/test/common/parallel/chain/parallel-chain-factory.specs.ts
@@ -18,7 +18,6 @@ describe("createParallelChain", function () {
         generator = new ParallelCollectionGenerator([1, 2, 3, 4]);
         options = {
             functionCallSerializer: undefined as any,
-            maxConcurrencyLevel: 2,
             scheduler: undefined as any,
             threadPool: undefined as any
         };

--- a/test/common/parallel/chain/parallel-chain-impl.specs.ts
+++ b/test/common/parallel/chain/parallel-chain-impl.specs.ts
@@ -30,7 +30,6 @@ describe("ParallelChainImpl", function () {
 
         options = {
             functionCallSerializer: undefined as any,
-            maxConcurrencyLevel: 2,
             scheduler: undefined as any,
             threadPool: undefined as any
         };

--- a/test/common/parallel/chain/pending-parallel-chain-state.specs.ts
+++ b/test/common/parallel/chain/pending-parallel-chain-state.specs.ts
@@ -21,7 +21,6 @@ describe("PendingParallelChainState", function () {
         scheduleSpy = scheduler.schedule as jasmine.Spy;
         options = {
             functionCallSerializer: undefined as any,
-            maxConcurrencyLevel: 2,
             scheduler,
             threadPool: undefined as any
         };

--- a/test/common/parallel/chain/scheduled-parallel-chain-state.specs.ts
+++ b/test/common/parallel/chain/scheduled-parallel-chain-state.specs.ts
@@ -15,7 +15,6 @@ describe("ScheduledParallelChainState", function () {
     beforeEach(function () {
         options = {
             functionCallSerializer: undefined as any,
-            maxConcurrencyLevel: 2,
             scheduler: undefined as any,
             threadPool: undefined as any
         };

--- a/test/common/parallel/parallel-impl.specs.ts
+++ b/test/common/parallel/parallel-impl.specs.ts
@@ -19,7 +19,6 @@ describe("Parallel", function () {
     let functionCallSerializer: FunctionCallSerializer;
     let serializeFunctionCallSpy: jasmine.Spy;
 
-    const maxConcurrencyLevel = 2;
     let createParallelChainSpy: jasmine.Spy;
     let options: IDefaultInitializedParallelOptions;
 
@@ -33,7 +32,6 @@ describe("Parallel", function () {
 
         options = {
             functionCallSerializer,
-            maxConcurrencyLevel,
             threadPool,
             scheduler: undefined as any
         };
@@ -49,14 +47,6 @@ describe("Parallel", function () {
             expect(defaultOptions).toBeDefined();
         });
 
-        it("initializes the maxConcurrencyLevel from the configuration by default", function () {
-            // act
-            const defaultOptions = parallel.defaultOptions();
-
-            // assert
-            expect(defaultOptions.maxConcurrencyLevel).toBe(maxConcurrencyLevel);
-        });
-
         it("initializes the thread pool to the thread pool from the configuration by default", function () {
             // act
             const defaultOptions = parallel.defaultOptions();
@@ -68,21 +58,18 @@ describe("Parallel", function () {
         it("applies the user options as new default options", function () {
             // act
             parallel.defaultOptions({
-                maxConcurrencyLevel: 8,
                 minValuesPerTask: 1000
             });
 
             // assert
             const defaultOptions = parallel.defaultOptions();
 
-            expect(defaultOptions.maxConcurrencyLevel).toBe(8);
             expect(defaultOptions.minValuesPerTask).toBe(1000);
         });
 
         it("merges the given options with the existing options", function () {
             // act
             parallel.defaultOptions({
-                maxConcurrencyLevel: 8,
                 minValuesPerTask: 1000
             });
 
@@ -105,16 +92,6 @@ describe("Parallel", function () {
             // assert
             const defaultOptions = parallel.defaultOptions();
             expect(defaultOptions.minValuesPerTask).toBeUndefined();
-        });
-
-        it("throws if maxConcurrencyLevel is not a number", function () {
-            // act, assert
-            expect(() => parallel.defaultOptions({ maxConcurrencyLevel: "test" } as any)).toThrowError("The maxConcurrencyLevel is mandatory and has to be a number");
-        });
-
-        it("throws if maxConcurrencyLevel is set to undefined", function () {
-            // act, assert
-            expect(() => parallel.defaultOptions({ maxConcurrencyLevel: undefined } as any)).toThrowError("The maxConcurrencyLevel is mandatory and has to be a number");
         });
 
         it("throws if the thread pool is set to undefined", function () {
@@ -146,7 +123,6 @@ describe("Parallel", function () {
 
             expect(createParallelChainSpy).toHaveBeenCalledWith(jasmine.any(ParallelCollectionGenerator), {
                 functionCallSerializer,
-                maxConcurrencyLevel,
                 maxValuesPerTask: 2,
                 threadPool,
                 scheduler: undefined
@@ -172,7 +148,6 @@ describe("Parallel", function () {
 
             expect(createParallelChainSpy).toHaveBeenCalledWith(jasmine.any(ParallelRangeGenerator), {
                 functionCallSerializer,
-                maxConcurrencyLevel,
                 maxValuesPerTask: 2,
                 threadPool,
                 scheduler: undefined
@@ -200,7 +175,6 @@ describe("Parallel", function () {
 
             expect(createParallelChainSpy).toHaveBeenCalledWith(jasmine.any(ParallelTimesGenerator), {
                 functionCallSerializer,
-                maxConcurrencyLevel,
                 maxValuesPerTask: 2,
                 threadPool,
                 scheduler: undefined

--- a/test/common/parallel/parallel-options.specs.ts
+++ b/test/common/parallel/parallel-options.specs.ts
@@ -2,7 +2,6 @@ import {validateOptions} from "../../../src/common/parallel/parallel-options";
 describe("validateOptions", function () {
     it("does not throw for valid options", function () {
         validateOptions({
-            maxConcurrencyLevel: 4,
             maxDegreeOfParallelism: 1,
             maxValuesPerTask: 4,
             minValuesPerTask: 2
@@ -16,35 +15,29 @@ describe("validateOptions", function () {
         })).toThrowError("Illegal parallel options: minValuesPerTask (4) must be equal or less than maxValuesPerTask (2).");
     });
 
-    it("ensures that maxDegreeOfParallelism is an int", function () {
-        const options = ({
-            maxDegreeOfParallelism: 2.3
-        });
-
-        // act
-        validateOptions(options);
-
-        // assert
-        expect(options.maxDegreeOfParallelism).toBe(2);
-    });
-
-    for (const option of ["maxConcurrencyLevel", "maxDegreeOfParallelism", "maxValuesPerTask", "minValuesPerTask"]) {
+    for (const option of ["maxDegreeOfParallelism", "maxValuesPerTask", "minValuesPerTask"]) {
         it(`throws if ${option} is not a number`, function () {
             expect(() => validateOptions({
                 [option]: "2"
-            })).toThrowError(`Illegal parallel options: ${option} (2) must be number greater than zero`);
+            })).toThrowError(`Illegal parallel options: ${option} (2) has to be an integer greater than zero`);
+        });
+
+        it(`throws if ${option} is not an integer`, function () {
+            expect(() => validateOptions({
+                [option]: 0.4
+            })).toThrowError(`Illegal parallel options: ${option} (0.4) has to be an integer greater than zero`);
         });
 
         it(`throws if ${option} is zero`, function () {
             expect(() => validateOptions({
                 [option]: 0
-            })).toThrowError(`Illegal parallel options: ${option} (0) must be number greater than zero`);
+            })).toThrowError(`Illegal parallel options: ${option} (0) has to be an integer greater than zero`);
         });
 
         it(`throws if ${option} is negative`, function () {
             expect(() => validateOptions({
                 [option]: -3
-            })).toThrowError(`Illegal parallel options: ${option} (-3) must be number greater than zero`);
+            })).toThrowError(`Illegal parallel options: ${option} (-3) has to be an integer greater than zero`);
         });
     }
 });

--- a/test/common/parallel/scheduling/abstract-parallel-scheduler.specs.ts
+++ b/test/common/parallel/scheduling/abstract-parallel-scheduler.specs.ts
@@ -34,12 +34,12 @@ describe("AbstractParallelScheduler", function () {
 
         threadPoolRunSpy = jasmine.createSpy("scheduleTask");
         threadPool = {
+            maxThreads: 2,
             run: threadPoolRunSpy
         };
 
         options = {
             functionCallSerializer: functionSerializer,
-            maxConcurrencyLevel: 2,
             scheduler,
             threadPool
         };

--- a/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
+++ b/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
@@ -9,9 +9,8 @@ describe("DefaultParallelScheduler", function () {
         scheduler = new DefaultParallelScheduler();
         options = {
             functionCallSerializer: undefined as any,
-            maxConcurrencyLevel: 2,
             scheduler,
-            threadPool: undefined as any
+            threadPool: { maxThreads: 2 } as any
         };
     });
 
@@ -21,7 +20,7 @@ describe("DefaultParallelScheduler", function () {
             const scheduling = scheduler.getScheduling(10, options);
 
             // assert
-            expect(scheduling.numberOfTasks).toBe(options.maxConcurrencyLevel * 4);
+            expect(scheduling.numberOfTasks).toBe(8);
         });
 
         it("uses options.maxValuesPerTask as upper items limit", function () {

--- a/test/common/parallel/stream/scheduled-parallel-stream.specs.ts
+++ b/test/common/parallel/stream/scheduled-parallel-stream.specs.ts
@@ -1,3 +1,4 @@
+
 import {ITask} from "../../../../src/common/task/task";
 import {IParallelStream} from "../../../../src/common/parallel/stream/parallel-stream";
 import {IParallelTaskDefinition} from "../../../../src/common/parallel/parallel-task-definition";

--- a/test/common/thread-pool/default-thread-pool.specs.ts
+++ b/test/common/thread-pool/default-thread-pool.specs.ts
@@ -13,6 +13,32 @@ describe("DefaultThreadPool", function () {
         threadPool = new DefaultThreadPool(workerThreadFactory, { maxConcurrencyLevel: 2 });
     });
 
+    describe("maxThreads", function () {
+        it("returns the maxConcurrencyLevel constructor argument by default", function () {
+            expect(threadPool.maxThreads).toEqual(2);
+        });
+
+        it("sets the maxThreads limit", function () {
+            // act
+            threadPool.maxThreads = 10;
+
+            // assert
+            expect(threadPool.maxThreads).toEqual(10);
+        });
+
+        it("throws if the value is not a number", function () {
+            expect(() => threadPool.maxThreads = undefined as any).toThrowError("The maxThreads limit (undefined) has to be a positive integer larger than zero.");
+        });
+
+        it("throws if the value is not an int", function () {
+            expect(() => threadPool.maxThreads = 2.1).toThrowError("The maxThreads limit (2.1) has to be a positive integer larger than zero.");
+        });
+
+        it("throws if the value is negative", function () {
+            expect(() => threadPool.maxThreads = -1).toThrowError("The maxThreads limit (-1) has to be a positive integer larger than zero.");
+        });
+    });
+
     describe("run", function () {
         let task: ITaskDefinition;
         let worker1RunSpy: jasmine.Spy;


### PR DESCRIPTION
Instead of having the property on ParallelOptions and the thread pool only define the option on the thread pool. This ensures that the option is kept in sync and reduces confusion that changing the option in parallel.defaultOptions does not affect the thread pool at all.

Fixes #86