### PR TITLE
Use Function Bind When Possible

### DIFF
--- a/src/common/function/function-call-deserializer.ts
+++ b/src/common/function/function-call-deserializer.ts
@@ -2,6 +2,23 @@ import {IFunctionLookupTable} from "./function-lookup-table";
 import {ISerializedFunctionCall, isSerializedFunctionCall} from "./serialized-function-call";
 
 /**
+ * Binds the function to undefined and the given params. Uses Function.bind if available or creates its own wrapper
+ * if not.
+ * @param fn the function to bind to the given parameters
+ * @param params the parameters to which the function is partially bound
+ * @returns a partially bound function
+ */
+function bind<TResult>(fn: Function, params: any[]): (...args: any[]) => TResult {
+    if (typeof(fn.bind) === "function") {
+        return fn.bind(undefined, ...params);
+    }
+
+    return function bound(...additionalParams: any[]) {
+        return fn.apply(undefined, params.concat(additionalParams)) as TResult;
+    };
+}
+
+/**
  * Deserializer for a {@link ISerializedFunctionCall}.
  */
 export class FunctionCallDeserializer {
@@ -34,8 +51,6 @@ export class FunctionCallDeserializer {
             });
         }
 
-        return function (...additionalParams: any[]) {
-            return func.apply(undefined, params.concat(additionalParams)) as TResult;
-        };
+        return bind<TResult>(func, params);
     }
 }

--- a/src/common/function/slave-function-lookup-table.ts
+++ b/src/common/function/slave-function-lookup-table.ts
@@ -50,7 +50,7 @@ export class SlaveFunctionLookupTable implements IFunctionLookupTable {
     private toFunction(definition: IFunctionDefinition): Function {
         if (definition.name) {
             const args = definition.argumentNames.join(", ");
-            const wrapper = Function.apply(undefined, [`return function ${definition.name} (${args}) { ${definition.body}}` ]);
+            const wrapper = Function.apply(undefined, [`return function ${definition.name} (${args}) { ${definition.body} }; ` ]);
             return wrapper();
         }
         return Function.apply(undefined, [...definition.argumentNames, definition.body]);


### PR DESCRIPTION
Function bind is significantly faster compared to a manual implementation. Use bind when available.
https://jsperf.com/bind-vs-custom-wrapper5