### PR TITLE
Fix getFunctionName for anonymous funcExpr

### DIFF
--- a/src/common/util/function-name.ts
+++ b/src/common/util/function-name.ts
@@ -11,5 +11,12 @@ export function getFunctionName(func: Function): string {
     }
 
     const source = func.toString();
-    return source.substring(source.indexOf("function") + 9, source.indexOf("(")).trim();
+    const functionKeywordStart = source.indexOf("function");
+
+    // Arrow Function Expressions
+    if (functionKeywordStart === -1) {
+        return "";
+    }
+
+    return source.substring(functionKeywordStart + 8, source.indexOf("(")).trim();
 }

--- a/test/common/util/function-name.specs.ts
+++ b/test/common/util/function-name.specs.ts
@@ -17,4 +17,8 @@ describe("getFunctionName", function () {
     it("returns an empty string for arrow functions", function () {
         expect(getFunctionName(() => 10)).toEqual("");
     });
+
+    it("returns am empty string even if the function has no space after the function keyword", function () {
+        expect(getFunctionName(function(memo: any, count: any) { return memo + count; })).toEqual("");
+    });
 });


### PR DESCRIPTION
Fix getFunctionName for anonymous FunctionExpressions that do not have a space after the function keyword