### PR TITLE
Expose valuesPerTask and taskIndex to environment provider

### DIFF
--- a/src/common/parallel/chain/parallel-chain.ts
+++ b/src/common/parallel/chain/parallel-chain.ts
@@ -32,14 +32,14 @@ export interface IParallelChain<TIn, TEnv extends IParallelEnvironment, TOut> ex
      * @param TEnvNew the type of the environment
      * @returns the chain
      */
-    inEnvironment<TEnvNew extends IParallelEnvironment>(provider: (this: void) => TEnvNew): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
+    inEnvironment<TEnvNew extends IParallelEnvironment>(provider: (this: void, taskEnv: TEnv & IParallelTaskEnvironment) => TEnvNew): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
     inEnvironment<TEnvNew extends IParallelEnvironment>(provider: IFunctionId): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
 
     /**
      * @param param1 single parameter that is passed to the provider
      * @param TParam1 the type of the single parameter
      */
-    inEnvironment<TParam1, TEnvNew extends IParallelEnvironment>(provider: (this: void, arg1: TParam1) => TEnvNew, param1: TParam1): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
+    inEnvironment<TParam1, TEnvNew extends IParallelEnvironment>(provider: (this: void, arg1: TParam1, taskEnv: TEnv & IParallelTaskEnvironment) => TEnvNew, param1: TParam1): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
 
     /**
      *
@@ -48,19 +48,19 @@ export interface IParallelChain<TIn, TEnv extends IParallelEnvironment, TOut> ex
      * @param TParam1 type of the first parameter
      * @param TParam2 type of the second parameter
      */
-    inEnvironment<TParam1, TParam2, TEnvNew extends IParallelEnvironment>(provider: (this: void, arg1: TParam1, arg2: TParam2) => TEnvNew, param1: TParam1, param2: TParam2): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
+    inEnvironment<TParam1, TParam2, TEnvNew extends IParallelEnvironment>(provider: (this: void, arg1: TParam1, arg2: TParam2, taskEnv: TEnv & IParallelTaskEnvironment) => TEnvNew, param1: TParam1, param2: TParam2): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
 
     /**
      * @param param3 third parameter that is passed to the provider funciton
      * @param TParam3 type of the third parameter
      */
-    inEnvironment<TParam1, TParam2, TParam3, TEnvNew extends IParallelEnvironment>(provider: (this: void, arg1: TParam1, arg2: TParam2, arg3: TParam3) => TEnvNew, param1: TParam1, param2: TParam2, param3: TParam3): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
+    inEnvironment<TParam1, TParam2, TParam3, TEnvNew extends IParallelEnvironment>(provider: (this: void, arg1: TParam1, arg2: TParam2, arg3: TParam3, taskEnv: TEnv & IParallelTaskEnvironment) => TEnvNew, param1: TParam1, param2: TParam2, param3: TParam3): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
 
     /**
      * @param param4 fourth parameter that is passed to the provider function
      * @param TParam4 type of the fourth parameter
      */
-    inEnvironment<TParam1, TParam2, TParam3, TParam4, TEnvNew extends IParallelEnvironment>(provider: (this: void, arg1: TParam1, arg2: TParam2, arg3: TParam3, arg4: TParam4) => TEnvNew, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
+    inEnvironment<TParam1, TParam2, TParam3, TParam4, TEnvNew extends IParallelEnvironment>(provider: (this: void, arg1: TParam1, arg2: TParam2, arg3: TParam3, arg4: TParam4, taskEnv: TEnv & IParallelTaskEnvironment) => TEnvNew, param1: TParam1, param2: TParam2, param3: TParam3, param4: TParam4): IParallelChain<TIn, TEnv & TEnvNew, TOut>;
 
     /**
      * @param furtherParams further paramters that are passed to the provider function

--- a/src/common/parallel/slave/parallel-job-executor.ts
+++ b/src/common/parallel/slave/parallel-job-executor.ts
@@ -35,19 +35,19 @@ export interface IParallelJobDefinition {
 }
 
 function createTaskEnvironment(definition: IParallelJobDefinition, functionCallDeserializer: FunctionCallDeserializer): IParallelTaskEnvironment {
-    let taskEnvironment: IParallelEnvironment = {};
+    let taskEnvironment: IParallelTaskEnvironment = { taskIndex: definition.taskIndex, valuesPerTask: definition.valuesPerTask };
 
     for (const environment of definition.environments) {
         let currentEnvironment: IParallelEnvironment;
         if (isSerializedFunctionCall(environment)) {
-            currentEnvironment = functionCallDeserializer.deserializeFunctionCall(environment)();
+            currentEnvironment = functionCallDeserializer.deserializeFunctionCall(environment)(taskEnvironment);
         } else {
             currentEnvironment = environment;
         }
-        assign(taskEnvironment, currentEnvironment);
+        taskEnvironment = assign({}, taskEnvironment, currentEnvironment);
     }
 
-    return assign({}, { taskIndex: definition.taskIndex, valuesPerTask: definition.valuesPerTask }, taskEnvironment);
+    return taskEnvironment;
 }
 
 /**

--- a/test/browser/parallel.integration.specs.ts
+++ b/test/browser/parallel.integration.specs.ts
@@ -52,4 +52,21 @@ describe("ParallelIntegration", function () {
             })
             .catch(() => done.fail());
     });
+
+    it("allows to run a single task", function (done) {
+        function fib(num: number): number {
+            if (num <= 2) {
+                return 1;
+            }
+
+            return fib(num - 1) + fib(num - 2);
+        }
+
+        parallel.run(fib, 10)
+            .then(result => {
+                expect(result).toEqual(55);
+                done();
+            })
+            .catch(() => done.fail());
+    });
 });

--- a/test/common/parallel/slave/parallel-job-executor.specs.ts
+++ b/test/common/parallel/slave/parallel-job-executor.specs.ts
@@ -136,6 +136,47 @@ describe("parallelJobExecutor", function () {
             expect(coordinator).toHaveBeenCalledWith(iterator, iteratee, { taskIndex: 0, test: 10, valuesPerTask: 2 });
         });
 
+        it("passes valuesPerTask and taskIndex to the environment provider", function () {
+            // arrange
+            const iterator = toIterator([1, 2, 3]);
+            const environmentProvider = jasmine.createSpy("environmentProvider").and.returnValue({ test: 10 });
+            const generator = jasmine.createSpy("generator").and.returnValue(iterator);
+            const coordinator = jasmine.createSpy("coordinator").and.returnValue(toIterator([2, 4]));
+            const iteratee = jasmine.createSpy("iteratee");
+            spyOn(deserializer, "deserializeFunctionCall").and.returnValues(environmentProvider, generator, coordinator, iteratee);
+
+            // act
+            parallelJobExecutor({
+                environments: [{
+                    ______serializedFunctionCall: true,
+                    functionId: functionId("test", 1003),
+                    parameters: []
+                }],
+                generator: {
+                    ______serializedFunctionCall: true,
+                    functionId: functionId("test", 1000),
+                    parameters: []
+                },
+                operations: [{
+                    iteratee: {
+                        ______serializedFunctionCall: true,
+                        functionId: functionId("test", 1002),
+                        parameters: []
+                    },
+                    iterator: {
+                        ______serializedFunctionCall: true,
+                        functionId: functionId("test", 1001),
+                        parameters: []
+                    }
+                }],
+                taskIndex: 0,
+                valuesPerTask: 2
+            }, { functionCallDeserializer: deserializer });
+
+            // assert
+            expect(environmentProvider).toHaveBeenCalledWith({ taskIndex: 0, valuesPerTask: 2 });
+        });
+
         it("merges the environments", function () {
             // arrange
             const iterator = toIterator([1, 2, 3]);


### PR DESCRIPTION
Needed if the environment depends upon the values processed by this task.