### PR TITLE
Serialized Function Calls as Environments were Merged

### DIFF
--- a/src/common/function/function-call.ts
+++ b/src/common/function/function-call.ts
@@ -4,6 +4,7 @@
 /** */
 
 import {IFunctionId} from "./function-id";
+import {ISerializedFunctionCall} from "./serialized-function-call";
 
 /**
  * Represents a function call
@@ -56,6 +57,15 @@ export class FunctionCall {
      */
     public static createUnchecked(func: Function | IFunctionId, ...params: any[]) {
         return new FunctionCall(func, params);
+    }
+
+    /**
+     * Creates a function call instance from its serialized representation
+     * @param serialized the serialized function call
+     * @returns {FunctionCall} the function call
+     */
+    public static fromSerialized(serialized: ISerializedFunctionCall): FunctionCall {
+        return new FunctionCall(serialized.functionId, serialized.parameters);
     }
 
     /**

--- a/src/common/parallel/chain/parallel-chain-impl.ts
+++ b/src/common/parallel/chain/parallel-chain-impl.ts
@@ -5,7 +5,8 @@ import {IParallelEnvironment, IParallelTaskEnvironment} from "../parallel-enviro
 import {FunctionCall} from "../../function/function-call";
 import {IParallelChainState, IParallelChainEnvironment} from "./parallel-chain-state";
 import {ParallelStream} from "../stream/parallel-stream-impl";
-import {IFunctionId} from "../../function/function-id";
+import {IFunctionId, isFunctionId} from "../../function/function-id";
+import {isSerializedFunctionCall} from "../../function/serialized-function-call";
 
 /**
  * Implementation of a {@link IParallelChain}
@@ -32,8 +33,10 @@ export class ParallelChainImpl<TIn, TEnv extends IParallelEnvironment, TOut> imp
     // region Chaining
     public inEnvironment<TEnvNew extends IParallelEnvironment>(newEnv: Function | IParallelEnvironment | IFunctionId, ...params: any[]): IParallelChain<TIn, TEnv & TEnvNew, TOut> {
         let env: IParallelChainEnvironment | undefined;
-        if (typeof newEnv === "function") {
+        if (typeof newEnv === "function" || isFunctionId(newEnv)) {
             env = FunctionCall.createUnchecked(newEnv, ...params);
+        } else if (isSerializedFunctionCall(newEnv)) {
+            env = FunctionCall.fromSerialized(newEnv);
         } else {
             env = newEnv;
         }

--- a/src/common/parallel/chain/parallel-chain.ts
+++ b/src/common/parallel/chain/parallel-chain.ts
@@ -76,7 +76,7 @@ export interface IParallelChain<TIn, TEnv extends IParallelEnvironment, TOut> ex
     map<TResult>(mapper: IFunctionId ): IParallelChain<TIn, TEnv, TResult>;
 
     /**
-     * Reduces the elements to a single value using the givne accumulator. The accumulator is invoked with the - up to now - accumulated value
+     * Reduces the elements to a single value using the given accumulator. The accumulator is invoked with the - up to now - accumulated value
      * and the current element and returns the sum of the accumulated value and the current value.
      * @param defaultValue default value to use to initialize the accumulator
      * @param accumulator the accumulator function

--- a/test/common/parallel/parallel-environment-definition.specs.ts
+++ b/test/common/parallel/parallel-environment-definition.specs.ts
@@ -63,6 +63,17 @@ describe("ParallelEnvironmentDefinition", function () {
             // act, assert
             expect(definition.add({ name: "Müller" }).environments).toEqual([{name: "Müller"}]);
         });
+
+        it("does not merge succeeding environment providers", function () {
+            // arrange
+            const provider1 = FunctionCall.create(() => ({ value: 1 }));
+            const provider2 = FunctionCall.create(() => ({ value: 2 }));
+
+            const definition = ParallelEnvironmentDefinition.of(provider1);
+
+            // act, assert
+            expect(definition.add(provider2).environments).toEqual([provider1, provider2]);
+        });
     });
 
     describe("toJSON", function () {


### PR DESCRIPTION
Instead of merging, each function call should be transmitted separately