### PR TITLE
Fix Parallel scheduling for non-integer valuesPerTask

### DIFF
--- a/src/common/parallel/scheduling/default-parallel-scheduler.ts
+++ b/src/common/parallel/scheduling/default-parallel-scheduler.ts
@@ -19,19 +19,21 @@ export class DefaultParallelScheduler extends AbstractParallelScheduler {
             maxDegreeOfParallelism = options.threadPool.maxThreads * 4;
         }
 
-        let itemsPerTask = totalNumberOfValues / maxDegreeOfParallelism;
+        let valuesPerTask = totalNumberOfValues / maxDegreeOfParallelism;
 
         if (options.minValuesPerTask) {
-            itemsPerTask = Math.min(Math.max(itemsPerTask, options.minValuesPerTask), totalNumberOfValues);
+            valuesPerTask = Math.min(Math.max(valuesPerTask, options.minValuesPerTask), totalNumberOfValues);
         }
 
         if (options.maxValuesPerTask) {
-            itemsPerTask = Math.min(itemsPerTask, options.maxValuesPerTask);
+            valuesPerTask = Math.min(valuesPerTask, options.maxValuesPerTask);
         }
 
+        valuesPerTask = Math.ceil(valuesPerTask);
+
         return {
-            numberOfTasks: itemsPerTask === 0 ? 0 : Math.round(totalNumberOfValues / itemsPerTask),
-            valuesPerTask: Math.ceil(itemsPerTask)
+            numberOfTasks: valuesPerTask === 0 ? 0 : Math.ceil(totalNumberOfValues / valuesPerTask),
+            valuesPerTask
         };
     }
 }

--- a/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
+++ b/test/common/parallel/scheduling/default-parallel-scheduler.specs.ts
@@ -17,7 +17,7 @@ describe("DefaultParallelScheduler", function () {
     describe("getScheduling", function () {
         it("returns the options.maxConcurrencyLevel * 4 as numberOfTasks by default", function () {
             // act
-            const scheduling = scheduler.getScheduling(10, options);
+            const scheduling = scheduler.getScheduling(16, options);
 
             // assert
             expect(scheduling.numberOfTasks).toBe(8);
@@ -40,7 +40,7 @@ describe("DefaultParallelScheduler", function () {
             options.maxValuesPerTask = 6;
 
             // act
-            const scheduling = scheduler.getScheduling(10, options);
+            const scheduling = scheduler.getScheduling(16, options);
 
             // assert
             expect(scheduling.valuesPerTask).toBe(2);
@@ -90,6 +90,31 @@ describe("DefaultParallelScheduler", function () {
             // assert
             expect(scheduling.numberOfTasks).toBe(2);
             expect(scheduling.valuesPerTask).toBe(10);
+        });
+
+        it("rounds the values per task before calculating the number of tasks", function () {
+            // arrange
+            options.threadPool.maxThreads = 4;
+
+            // act
+            const scheduling = scheduler.getScheduling(10, options);
+
+            // assert
+            expect(scheduling.numberOfTasks).toBe(10);
+            expect(scheduling.valuesPerTask).toBe(1);
+        });
+
+        it("rounds the number of tasks up", function () {
+            // arrange
+            options.maxValuesPerTask = 3;
+            options.minValuesPerTask = 3;
+
+            // act
+            const scheduling = scheduler.getScheduling(10, options);
+
+            // assert
+            expect(scheduling.numberOfTasks).toBe(4);
+            expect(scheduling.valuesPerTask).toBe(3);
         });
     });
 });


### PR DESCRIPTION
If the calculated values per task is not even, than the value must be rounded up and the rounded value must be used to calculate the number of tasks
Otherwise the calculated number of tasks might be larger than whats actually needed.